### PR TITLE
Graph: Out Edges from vertex

### DIFF
--- a/Graph/Graph/AdjacencyListGraph.swift
+++ b/Graph/Graph/AdjacencyListGraph.swift
@@ -26,11 +26,11 @@ public class AdjacencyListGraph<T where T: Equatable, T: Hashable>: AbstractGrap
 
   private var adjacencyList: [EdgeList<T>] = []
 
-  public override init() {
+  public required init() {
     super.init()
   }
 
-  public override init(fromGraph graph: AbstractGraph<T>) {
+  public required init(fromGraph graph: AbstractGraph<T>) {
     super.init(fromGraph: graph)
   }
 
@@ -105,6 +105,10 @@ public class AdjacencyListGraph<T where T: Equatable, T: Hashable>: AbstractGrap
     }
 
     return nil
+  }
+
+  public override func edgesFrom(sourceVertex: Vertex<T>) -> [Edge<T>] {
+    return adjacencyList[sourceVertex.index].edges ?? []
   }
 
   public override var description: String {

--- a/Graph/Graph/AdjacencyMatrixGraph.swift
+++ b/Graph/Graph/AdjacencyMatrixGraph.swift
@@ -14,11 +14,11 @@ public class AdjacencyMatrixGraph<T where T: Equatable, T: Hashable>: AbstractGr
   private var adjacencyMatrix: [[Double?]] = []
   private var _vertices: [Vertex<T>] = []
 
-  public override init() {
+  public required init() {
     super.init()
   }
 
-  public override init(fromGraph graph: AbstractGraph<T>) {
+  public required init(fromGraph graph: AbstractGraph<T>) {
     super.init(fromGraph: graph)
   }
 
@@ -82,6 +82,17 @@ public class AdjacencyMatrixGraph<T where T: Equatable, T: Hashable>: AbstractGr
 
   public override func weightFrom(sourceVertex: Vertex<T>, to destinationVertex: Vertex<T>) -> Double? {
     return adjacencyMatrix[sourceVertex.index][destinationVertex.index]
+  }
+
+  public override func edgesFrom(sourceVertex: Vertex<T>) -> [Edge<T>] {
+    var outEdges = [Edge<T>]()
+    let fromIndex = sourceVertex.index
+    for column in 0..<adjacencyMatrix.count {
+      if let weight = adjacencyMatrix[fromIndex][column] {
+        outEdges.append(Edge(from: sourceVertex, to: vertices[column], weight: weight))
+      }
+    }
+    return outEdges
   }
 
   public override var description: String {

--- a/Graph/Graph/Graph.swift
+++ b/Graph/Graph/Graph.swift
@@ -9,9 +9,9 @@ import Foundation
 
 public class AbstractGraph<T where T: Equatable, T: Hashable>: CustomStringConvertible {
 
-  public init() {}
+  public required init() {}
 
-  public init(fromGraph graph: AbstractGraph<T>) {
+  public required init(fromGraph graph: AbstractGraph<T>) {
     for edge in graph.edges {
       let from = createVertex(edge.from.data)
       let to = createVertex(edge.to.data)
@@ -56,4 +56,7 @@ public class AbstractGraph<T where T: Equatable, T: Hashable>: CustomStringConve
     fatalError("abstract function called")
   }
 
+  public func edgesFrom(sourceVertex: Vertex<T>) -> [Edge<T>] {
+    fatalError("abstract function called")
+  }
 }

--- a/Graph/GraphTests/GraphTests.swift
+++ b/Graph/GraphTests/GraphTests.swift
@@ -53,5 +53,106 @@ class GraphTests: XCTestCase {
       XCTAssertEqual(graph.vertices.count, 1, "Graph should only contain one vertex after trying to create two vertices with identical data")
     }
   }
-    
+
+  func testEdgesFromReturnsCorrectEdgeInSingleEdgeDirecedGraphWithType(graphType: AbstractGraph<Int>.Type) {
+    let graph = graphType.init()
+
+    let a = graph.createVertex(1)
+    let b = graph.createVertex(2)
+
+    graph.addDirectedEdge(a, to: b, withWeight: 1.0)
+
+    let edgesFromA = graph.edgesFrom(a)
+    let edgesFromB = graph.edgesFrom(b)
+
+    XCTAssertEqual(edgesFromA.count, 1)
+    XCTAssertEqual(edgesFromB.count, 0)
+
+    XCTAssertEqual(edgesFromA.first?.to, b)
+  }
+
+  func testEdgesFromReturnsCorrectEdgeInSingleEdgeUndirectedGraphWithType(graphType: AbstractGraph<Int>.Type) {
+    let graph = graphType.init()
+
+    let a = graph.createVertex(1)
+    let b = graph.createVertex(2)
+
+    graph.addUndirectedEdge((a, b), withWeight: 1.0)
+
+    let edgesFromA = graph.edgesFrom(a)
+    let edgesFromB = graph.edgesFrom(b)
+
+    XCTAssertEqual(edgesFromA.count, 1)
+    XCTAssertEqual(edgesFromB.count, 1)
+
+    XCTAssertEqual(edgesFromA.first?.to, b)
+    XCTAssertEqual(edgesFromB.first?.to, a)
+  }
+
+  func testEdgesFromReturnsNoEdgesInNoEdgeGraphWithType(graphType: AbstractGraph<Int>.Type) {
+    let graph = graphType.init()
+
+    let a = graph.createVertex(1)
+    let b = graph.createVertex(2)
+
+    XCTAssertEqual(graph.edgesFrom(a).count, 0)
+    XCTAssertEqual(graph.edgesFrom(b).count, 0)
+  }
+
+  func testEdgesFromReturnsCorrectEdgesInBiggerGraphInDirectedGraphWithType(graphType: AbstractGraph<Int>.Type) {
+    let graph = graphType.init()
+    let verticesCount = 100
+    var vertices: [Vertex<Int>] = []
+
+    for i in 0..<verticesCount {
+      vertices.append(graph.createVertex(i))
+    }
+
+    for i in 0..<verticesCount {
+      for j in i+1..<verticesCount {
+        graph.addDirectedEdge(vertices[i], to: vertices[j], withWeight: 1)
+      }
+    }
+
+    for i in 0..<verticesCount {
+      let outEdges = graph.edgesFrom(vertices[i])
+      let toVertices = outEdges.map {return $0.to}
+      XCTAssertEqual(outEdges.count, verticesCount - i - 1)
+      for j in i+1..<verticesCount {
+        XCTAssertTrue(toVertices.contains(vertices[j]))
+      }
+    }
+  }
+
+  func testEdgesFromReturnsCorrectEdgeInSingleEdgeDirecedMatrixGraph() {
+    testEdgesFromReturnsCorrectEdgeInSingleEdgeDirecedGraphWithType(AdjacencyMatrixGraph<Int>)
+  }
+
+  func testEdgesFromReturnsCorrectEdgeInSingleEdgeUndirectedMatrixGraph() {
+    testEdgesFromReturnsCorrectEdgeInSingleEdgeUndirectedGraphWithType(AdjacencyMatrixGraph<Int>)
+  }
+
+  func testEdgesFromReturnsNoInNoEdgeMatrixGraph() {
+    testEdgesFromReturnsNoEdgesInNoEdgeGraphWithType(AdjacencyMatrixGraph<Int>)
+  }
+
+  func testEdgesFromReturnsCorrectEdgesInBiggerGraphInDirectedMatrixGraph() {
+    testEdgesFromReturnsCorrectEdgesInBiggerGraphInDirectedGraphWithType(AdjacencyMatrixGraph<Int>)
+  }
+
+  func testEdgesFromReturnsCorrectEdgeInSingleEdgeDirecedListGraph() {
+    testEdgesFromReturnsCorrectEdgeInSingleEdgeDirecedGraphWithType(AdjacencyListGraph<Int>)
+  }
+
+  func testEdgesFromReturnsCorrectEdgeInSingleEdgeUndirectedListGraph() {
+    testEdgesFromReturnsCorrectEdgeInSingleEdgeUndirectedGraphWithType(AdjacencyListGraph<Int>)
+  }
+
+  func testEdgesFromReturnsNoInNoEdgeListGraph() {
+    testEdgesFromReturnsNoEdgesInNoEdgeGraphWithType(AdjacencyListGraph<Int>)
+  }
+
+  func testEdgesFromReturnsCorrectEdgesInBiggerGraphInDirectedListGraph() {
+    testEdgesFromReturnsCorrectEdgesInBiggerGraphInDirectedGraphWithType(AdjacencyListGraph<Int>)
+  }
 }


### PR DESCRIPTION
Added graph function to get edges from a vertex – implemented both in AdjacencyMatrixGraph and AdjacencyListGraph.
Needed for graph algorithms.