### PR TITLE
Simplify midpoint calculation

### DIFF
--- a/Binary Search/BinarySearch.playground/Sources/BinarySearch.swift
+++ b/Binary Search/BinarySearch.playground/Sources/BinarySearch.swift
@@ -17,7 +17,7 @@ public func binarySearch<T: Comparable>(_ a: [T], key: T, range: Range<Int>) -> 
     if range.lowerBound >= range.upperBound {
         return nil
     } else {
-        let midIndex = range.lowerBound + (range.upperBound - range.lowerBound) / 2
+        let midIndex = (range.lowerBound + range.upperBound) / 2
         if a[midIndex] > key {
             return binarySearch(a, key: key, range: range.lowerBound ..< midIndex)
         } else if a[midIndex] < key {
@@ -39,7 +39,7 @@ public func binarySearch<T: Comparable>(_ a: [T], key: T) -> Int? {
     var lowerBound = 0
     var upperBound = a.count
     while lowerBound < upperBound {
-        let midIndex = lowerBound + (upperBound - lowerBound) / 2
+        let midIndex = (lowerBound + upperBound) / 2
         if a[midIndex] == key {
             return midIndex
         } else if a[midIndex] < key {

--- a/Binary Search/BinarySearch.swift
+++ b/Binary Search/BinarySearch.swift
@@ -17,7 +17,7 @@ public func binarySearch<T: Comparable>(_ a: [T], key: T, range: Range<Int>) -> 
     if range.lowerBound >= range.upperBound {
         return nil
     } else {
-        let midIndex = range.lowerBound + (range.upperBound - range.lowerBound) / 2
+        let midIndex = (range.lowerBound + range.upperBound) / 2
         if a[midIndex] > key {
             return binarySearch(a, key: key, range: range.lowerBound ..< midIndex)
         } else if a[midIndex] < key {
@@ -39,7 +39,7 @@ public func binarySearch<T: Comparable>(_ a: [T], key: T) -> Int? {
     var lowerBound = 0
     var upperBound = a.count
     while lowerBound < upperBound {
-        let midIndex = lowerBound + (upperBound - lowerBound) / 2
+        let midIndex = (lowerBound + upperBound) / 2
         if a[midIndex] == key {
             return midIndex
         } else if a[midIndex] < key {


### PR DESCRIPTION
Simplify midpoint calculation by using `(x1 + x2) / 2`. This replaces `x1 + (x2 - x1) / 2`.