### PR TITLE
Fix memory leak in Tree implementation

### DIFF
--- a/Tree/README.markdown
+++ b/Tree/README.markdown
@@ -26,7 +26,7 @@ Here's a basic implementation in Swift:
 public class TreeNode<T> {
   public var value: T
 
-  public var parent: TreeNode?
+  public weak var parent: TreeNode?
   public var children = [TreeNode<T>]()
 
   public init(value: T) {

--- a/Tree/Tree.playground/Contents.swift
+++ b/Tree/Tree.playground/Contents.swift
@@ -3,7 +3,7 @@
 public class TreeNode<T> {
   public var value: T
 
-  public var parent: TreeNode?
+  public weak var parent: TreeNode?
   public var children = [TreeNode<T>]()
 
   public init(value: T) {

--- a/Tree/Tree.swift
+++ b/Tree/Tree.swift
@@ -1,7 +1,7 @@
 public class TreeNode<T> {
   public var value: T
 
-  public var parent: TreeNode?
+  public weak var parent: TreeNode?
   public var children = [TreeNode<T>]()
 
   public init(value: T) {


### PR DESCRIPTION
Caused by retain cycle between parent and child (parent has a strong reference to child, and child has a strong reference to parent).

Related to #92.