### PR TITLE
Modified the peek property name to front

### DIFF
--- a/Queue/Queue.playground/Contents.swift
+++ b/Queue/Queue.playground/Contents.swift
@@ -34,7 +34,7 @@ public struct Queue<T> {
     }
   }
 
-  public var peek: T? {
+  public var front: T? {
     return array.first
   }
 }
@@ -56,7 +56,7 @@ queueOfNames.dequeue()
 
 // Return the first element in the queue.
 // Returns "Lisa" since "Carl" was dequeued on the previous line.
-queueOfNames.peek
+queueOfNames.front
 
 // Check to see if the queue is empty.
 // Returns "false" since the queue still has elements in it.

--- a/Queue/Queue.playground/timeline.xctimeline
+++ b/Queue/Queue.playground/timeline.xctimeline
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<Timeline
-   version = "3.0">
-   <TimelineItems>
-   </TimelineItems>
-</Timeline>

--- a/Queue/README.markdown
+++ b/Queue/README.markdown
@@ -68,7 +68,7 @@ public struct Queue<T> {
     }
   }
   
-  public func peek() -> T? {
+  public var front: T? {
     return array.first
   }
 }
@@ -166,12 +166,8 @@ public struct Queue<T> {
     return element
   }
   
-  public func peek() -> T? {
-    if isEmpty {
-      return nil
-    } else {
-      return array[head]
-    }
+  public var front: T? {
+    return array.first
   }
 }
 ```


### PR DESCRIPTION
@hollance made a remark about this before, and Knuth's Fundamental Algorithms book p. 241 also refers to the first and last items in a queue as front and rear:

"_With queues, we speak of the front and the rear of the queue._"

This updates the `README` and playground files to reflect these changes.