### PR TITLE
Modified Stack peek property to front

### DIFF
--- a/Queue/Queue.playground/Contents.swift
+++ b/Queue/Queue.playground/Contents.swift
@@ -34,7 +34,7 @@ public struct Queue<T> {
     }
   }
 
-  public var peek: T? {
+  public var front: T? {
     return array.first
   }
 }
@@ -56,7 +56,7 @@ queueOfNames.dequeue()
 
 // Return the first element in the queue.
 // Returns "Lisa" since "Carl" was dequeued on the previous line.
-queueOfNames.peek
+queueOfNames.front
 
 // Check to see if the queue is empty.
 // Returns "false" since the queue still has elements in it.

--- a/Queue/Queue.playground/timeline.xctimeline
+++ b/Queue/Queue.playground/timeline.xctimeline
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<Timeline
-   version = "3.0">
-   <TimelineItems>
-   </TimelineItems>
-</Timeline>

--- a/Queue/README.markdown
+++ b/Queue/README.markdown
@@ -68,7 +68,7 @@ public struct Queue<T> {
     }
   }
   
-  public func peek() -> T? {
+  public var front: T? {
     return array.first
   }
 }
@@ -166,12 +166,8 @@ public struct Queue<T> {
     return element
   }
   
-  public func peek() -> T? {
-    if isEmpty {
-      return nil
-    } else {
-      return array[head]
-    }
+  public var front: T? {
+    return array.first
   }
 }
 ```

--- a/Stack/README.markdown
+++ b/Stack/README.markdown
@@ -38,7 +38,7 @@ stack.pop()
 
 This returns `3`, and so on. If the stack is empty, popping returns `nil` or in some implementations it gives an error message ("stack underflow").
 
-A stack is easy to create in Swift. It's just a wrapper around an array that just lets you push, pop, and peek:
+A stack is easy to create in Swift. It's just a wrapper around an array that just lets you push, pop, and look at the top element of the stack:
 
 ```swift
 public struct Stack<T> {
@@ -60,8 +60,8 @@ public struct Stack<T> {
     return array.popLast()
   }
 
-  public func peek() -> T? {
-    return array.last
+  public var top: T? {
+  	return array.last
   }
 }
 ```

--- a/Stack/Stack.playground/Contents.swift
+++ b/Stack/Stack.playground/Contents.swift
@@ -30,7 +30,7 @@ public struct Stack<T> {
     return array.popLast()
   }
 
-  public func peek() -> T? {
+  public var top: T? {
     return array.last
   }
 }
@@ -49,7 +49,7 @@ stackOfNames.pop()
 
 // Look at the first element from the stack.
 // Returns "Wade" since "Mike" was popped on the previous line.
-stackOfNames.peek()
+stackOfNames.top
 
 // Check to see if the stack is empty.
 // Returns "false" since the stack still has elements in it.


### PR DESCRIPTION
This change is inspired by the Swift naming conventions guide and Knuth's fundamental algorithms book page 242 where he states the element at the top of the stack may be denoted by top(A) where A is the stack.