### PR TITLE
Update Stack and Queue files to use top and front properties

### DIFF
--- a/Queue/Queue-Optimized.swift
+++ b/Queue/Queue-Optimized.swift
@@ -37,7 +37,7 @@ public struct Queue<T> {
     return element
   }
 
-  public func peek() -> T? {
+  public var front: T? {
     if isEmpty {
       return nil
     } else {

--- a/Queue/Queue-Simple.swift
+++ b/Queue/Queue-Simple.swift
@@ -30,7 +30,7 @@ public struct Queue<T> {
     }
   }
 
-  public func peek() -> T? {
+  public var front: T? {
     return array.first
   }
 }

--- a/Queue/README.markdown
+++ b/Queue/README.markdown
@@ -167,7 +167,11 @@ public struct Queue<T> {
   }
   
   public var front: T? {
-    return array.first
+    if isEmpty {
+      return nil
+    } else {
+      return array[head]
+    }
   }
 }
 ```

--- a/Queue/Tests/QueueTests.swift
+++ b/Queue/Tests/QueueTests.swift
@@ -6,7 +6,7 @@ class QueueTest: XCTestCase {
     var queue = Queue<Int>()
     XCTAssertTrue(queue.isEmpty)
     XCTAssertEqual(queue.count, 0)
-    XCTAssertEqual(queue.peek(), nil)
+    XCTAssertEqual(queue.front, nil)
     XCTAssertNil(queue.dequeue())
   }
 
@@ -16,13 +16,13 @@ class QueueTest: XCTestCase {
     queue.enqueue(123)
     XCTAssertFalse(queue.isEmpty)
     XCTAssertEqual(queue.count, 1)
-    XCTAssertEqual(queue.peek(), 123)
+    XCTAssertEqual(queue.front, 123)
 
     let result = queue.dequeue()
     XCTAssertEqual(result, 123)
     XCTAssertTrue(queue.isEmpty)
     XCTAssertEqual(queue.count, 0)
-    XCTAssertEqual(queue.peek(), nil)
+    XCTAssertEqual(queue.front, nil)
   }
 
   func testTwoElements() {
@@ -32,19 +32,19 @@ class QueueTest: XCTestCase {
     queue.enqueue(456)
     XCTAssertFalse(queue.isEmpty)
     XCTAssertEqual(queue.count, 2)
-    XCTAssertEqual(queue.peek(), 123)
+    XCTAssertEqual(queue.front, 123)
 
     let result1 = queue.dequeue()
     XCTAssertEqual(result1, 123)
     XCTAssertFalse(queue.isEmpty)
     XCTAssertEqual(queue.count, 1)
-    XCTAssertEqual(queue.peek(), 456)
+    XCTAssertEqual(queue.front, 456)
 
     let result2 = queue.dequeue()
     XCTAssertEqual(result2, 456)
     XCTAssertTrue(queue.isEmpty)
     XCTAssertEqual(queue.count, 0)
-    XCTAssertEqual(queue.peek(), nil)
+    XCTAssertEqual(queue.front, nil)
   }
 
   func testMakeEmpty() {
@@ -58,12 +58,12 @@ class QueueTest: XCTestCase {
 
     queue.enqueue(789)
     XCTAssertEqual(queue.count, 1)
-    XCTAssertEqual(queue.peek(), 789)
+    XCTAssertEqual(queue.front, 789)
 
     let result = queue.dequeue()
     XCTAssertEqual(result, 789)
     XCTAssertTrue(queue.isEmpty)
     XCTAssertEqual(queue.count, 0)
-    XCTAssertEqual(queue.peek(), nil)
+    XCTAssertEqual(queue.front, nil)
   }
 }

--- a/Stack/README.markdown
+++ b/Stack/README.markdown
@@ -61,7 +61,7 @@ public struct Stack<T> {
   }
 
   public var top: T? {
-  	return array.last
+    return array.last
   }
 }
 ```

--- a/Stack/Stack.swift
+++ b/Stack/Stack.swift
@@ -22,7 +22,7 @@ public struct Stack<T> {
     return array.popLast()
   }
 
-  public func peek() -> T? {
+  public var top: T? {
     return array.last
   }
 }

--- a/Stack/Tests/StackTests.swift
+++ b/Stack/Tests/StackTests.swift
@@ -6,7 +6,7 @@ class StackTest: XCTestCase {
     var stack = Stack<Int>()
     XCTAssertTrue(stack.isEmpty)
     XCTAssertEqual(stack.count, 0)
-    XCTAssertEqual(stack.peek(), nil)
+    XCTAssertEqual(stack.top, nil)
     XCTAssertNil(stack.pop())
   }
 
@@ -16,13 +16,13 @@ class StackTest: XCTestCase {
     stack.push(123)
     XCTAssertFalse(stack.isEmpty)
     XCTAssertEqual(stack.count, 1)
-    XCTAssertEqual(stack.peek(), 123)
+    XCTAssertEqual(stack.top, 123)
 
     let result = stack.pop()
     XCTAssertEqual(result, 123)
     XCTAssertTrue(stack.isEmpty)
     XCTAssertEqual(stack.count, 0)
-    XCTAssertEqual(stack.peek(), nil)
+    XCTAssertEqual(stack.top, nil)
     XCTAssertNil(stack.pop())
   }
 
@@ -33,19 +33,19 @@ class StackTest: XCTestCase {
     stack.push(456)
     XCTAssertFalse(stack.isEmpty)
     XCTAssertEqual(stack.count, 2)
-    XCTAssertEqual(stack.peek(), 456)
+    XCTAssertEqual(stack.top, 456)
 
     let result1 = stack.pop()
     XCTAssertEqual(result1, 456)
     XCTAssertFalse(stack.isEmpty)
     XCTAssertEqual(stack.count, 1)
-    XCTAssertEqual(stack.peek(), 123)
+    XCTAssertEqual(stack.top, 123)
 
     let result2 = stack.pop()
     XCTAssertEqual(result2, 123)
     XCTAssertTrue(stack.isEmpty)
     XCTAssertEqual(stack.count, 0)
-    XCTAssertEqual(stack.peek(), nil)
+    XCTAssertEqual(stack.top, nil)
     XCTAssertNil(stack.pop())
   }
 
@@ -60,13 +60,13 @@ class StackTest: XCTestCase {
 
     stack.push(789)
     XCTAssertEqual(stack.count, 1)
-    XCTAssertEqual(stack.peek(), 789)
+    XCTAssertEqual(stack.top, 789)
 
     let result = stack.pop()
     XCTAssertEqual(result, 789)
     XCTAssertTrue(stack.isEmpty)
     XCTAssertEqual(stack.count, 0)
-    XCTAssertEqual(stack.peek(), nil)
+    XCTAssertEqual(stack.top, nil)
     XCTAssertNil(stack.pop())
   }
 }


### PR DESCRIPTION
Hi Swift Algorithm Club team!

This PR has the following changes. Can I ask you to review them? Thanks 😃

## Changes

- Stack and Queue's `peek()` method was replaced with `top` and `front` properties with #322 PR. This PR updates Stack.swift, StackTests.swift, Queue-Simple.swift, Queue-Optimized.swift, and QueueTests.swift to use the changes.
- Fix Queue-Optimized front property implementation in Queue/README.markdown.
- Fix indentation in Stack/README.markdown.
