### PR TITLE
add SelectionSamplingExample.swift

### DIFF
--- a/Selection Sampling/SelectionSamplingExample.swift
+++ b/Selection Sampling/SelectionSamplingExample.swift
@@ -1,0 +1,32 @@
+//
+//  Select.swift
+//  
+//
+//  Created by Cheer on 2017/3/9.
+//
+//
+
+import Foundation
+
+func select<T>(from a: [T], count requested: Int) -> [T] {
+    
+    // if requested > a.count, will throw ==> fatal error: Index out of range
+    
+    if requested < a.count {
+        var arr = a
+        for i in 0..<requested {
+            
+            //arc4random_uniform(n) ==> the range is [0...n-1]
+            //So: arc4random_uniform(UInt32(arr.count - i - 2)) + (i + 1) ==> [0...arr.count - (i + 1) - 1] + (i + 1) ==> the range is [(i + 1)...arr.count - 1]
+            //Why start index is "(i + 1)"?  Because in "swap(&A,&B)", if A's index == B's index, will throw a error: "swapping a location with itself is not supported"
+            
+            let nextIndex = Int(arc4random_uniform(UInt32(arr.count - i - 2))) + (i + 1)
+            swap(&arr[nextIndex], &arr[i])
+        }
+        return Array(arr[0..<requested])
+    }
+    
+    if requested == a.count { return a }
+    
+    return [T]()
+}

--- a/Shell Sort/ShellSortExample.swift
+++ b/Shell Sort/ShellSortExample.swift
@@ -8,24 +8,25 @@
 
 import Foundation
 
-public func shellSort(_ list: inout [Int]) {
-    
+public func shellSort(_ list : inout [Int])
+{
     var sublistCount = list.count / 2
-   
-    while sublistCount > 0 {
-        
-        for index in 0..<list.count {
-           
-            guard index + sublistCount < list.count else { break }
+    
+    while sublistCount > 0
+    {
+        for var index in 0..<arr.count{
             
-            if list[index] > list[index + sublistCount] {
-                swap(&list[index], &list[index + sublistCount])
+            guard index + sublistCount < arr.count else { break }
+            
+            if arr[index] > arr[index + sublistCount]{
+                swap(&arr[index], &arr[index + sublistCount])
             }
             
             guard sublistCount == 1 && index > 0 else { continue }
-            
-            if list[index - 1] > list[index] {
-                swap(&list[index - 1], &list[index])
+
+            while arr[index - 1] > arr[index] && index - 1 > 0  {
+                swap(&arr[index - 1], &arr[index])
+                index -= 1
             }
         }
         sublistCount = sublistCount / 2


### PR DESCRIPTION
As shown in Figure,when ```count``` == 10,time consuming were 0.0053; 0.0136;0.0037.
But if ```count``` is near ```poem.count```,for example,```count``` == ```poem.count - 3```,time consuming were 0.0102; 0.0364;0.0058.

![image](https://cloud.githubusercontent.com/assets/15380331/23746750/03a6a20a-04f8-11e7-9cd6-f5d84118bc1c.png)
![image](https://cloud.githubusercontent.com/assets/15380331/23746758/0f365502-04f8-11e7-8123-df3ba08395c4.png)
![image](https://cloud.githubusercontent.com/assets/15380331/23746769/18c6365a-04f8-11e7-8951-4ad93bd0595a.png)
