### PR TITLE
Updated syntax for Swift 3

### DIFF
--- a/Binary Tree/BinaryTree.swift
+++ b/Binary Tree/BinaryTree.swift
@@ -29,26 +29,26 @@ extension BinaryTree: CustomStringConvertible {
 }
 
 extension BinaryTree {
-  public func traverseInOrder(@noescape process: T -> Void) {
+  public func traverseInOrder(process: T -> Void) {
     if case let .node(left, value, right) = self {
-      left.traverseInOrder(process)
+      left.traverseInOrder(process: process)
       process(value)
-      right.traverseInOrder(process)
+      right.traverseInOrder(process: process)
     }
   }
 
-  public func traversePreOrder(@noescape process: T -> Void) {
+  public func traversePreOrder(process: T -> Void) {
     if case let .node(left, value, right) = self {
       process(value)
-      left.traversePreOrder(process)
-      right.traversePreOrder(process)
+      left.traversePreOrder(process: process)
+      right.traversePreOrder(process: process)
     }
   }
 
-  public func traversePostOrder(@noescape process: T -> Void) {
+  public func traversePostOrder(process: T -> Void) {
     if case let .node(left, value, right) = self {
-      left.traversePostOrder(process)
-      right.traversePostOrder(process)
+      left.traversePostOrder(process: process)
+      right.traversePostOrder(process: process)
       process(value)
     }
   }


### PR DESCRIPTION
Hello, I was recreating this file in playground and I noticed you still had the explicit @noescape . Thought I can lend a hand by removing it. Thanks for this awesome repository!