### PR TITLE
Fix links to related articles

### DIFF
--- a/Queue/README.markdown
+++ b/Queue/README.markdown
@@ -255,8 +255,8 @@ The `nil` objects at the front have been removed and the array is no longer wast
 
 ## See also
 
-There are many other ways to create a queue. Alternative implementations use a [linked list](../Linked List/), a [circular buffer](../Ring Buffer/), or a [heap](../Heap/). 
+There are many other ways to create a queue. Alternative implementations use a [linked list](../Linked%20List/), a [circular buffer](../Ring%20Buffer/), or a [heap](../Heap/). 
 
-Variations on this theme are [deque](../Deque/), a double-ended queue where you can enqueue and dequeue at both ends, and [priority queue](../Priority Queue/), a sorted queue where the "most important" item is always at the front.
+Variations on this theme are [deque](../Deque/), a double-ended queue where you can enqueue and dequeue at both ends, and [priority queue](../Priority%20Queue/), a sorted queue where the "most important" item is always at the front.
 
 *Written for Swift Algorithm Club by Matthijs Hollemans*


### PR DESCRIPTION
Fixes links to Linked List, Ring Buffer, and Priority Queue directories.


[Rendered](https://github.com/jkrmr/swift-algorithm-club/blob/a54e722b035ffc5eeba63fcd5b1648e56f732ec0/Queue/README.markdown):
_____________________________________________
## See also

There are many other ways to create a queue. Alternative implementations use a [linked list](../Linked%20List/), a [circular buffer](../Ring%20Buffer/), or a [heap](../Heap/). 

Variations on this theme are [deque](../Deque/), a double-ended queue where you can enqueue and dequeue at both ends, and [priority queue](../Priority%20Queue/), a sorted queue where the "most important" item is always at the front.

