### PR TITLE
Fixing a bug in the Linked List logic

### DIFF
--- a/Linked List/LinkedList.playground/Contents.swift
+++ b/Linked List/LinkedList.playground/Contents.swift
@@ -73,7 +73,8 @@ public final class LinkedList<T> {
     self.append(newNode)
   }
   
-  public func append(_ newNode: Node) {
+  public func append(_ node: Node) {
+    let newNode = LinkedListNode(value: node.value)
     if let lastNode = last {
       newNode.previous = lastNode
       lastNode.next = newNode
@@ -104,9 +105,9 @@ public final class LinkedList<T> {
     self.insert(newNode, atIndex: index)
   }
   
-  public func insert(_ newNode: Node, atIndex index: Int) {
+  public func insert(_ node: Node, atIndex index: Int) {
     let (prev, next) = nodesBeforeAndAfter(index: index)
-    
+    let newNode = LinkedListNode(value: node.value)
     newNode.previous = prev
     newNode.next = next
     prev?.next = newNode
@@ -264,16 +265,16 @@ f    // [Universe, Swifty]
 //list.removeAll()
 //list.isEmpty
 
-list.remove(node: list.first!) // "Hello"
+list.remove(node: list.first!) // "Universe"
 list.count                     // 2
-list[0]                        // "Swift"
-list[1]                        // "World"
+list[0]                        // "Swifty"
+list[1]                        // "Hello"
 
-list.removeLast()              // "World"
+list.removeLast()              // "Hello"
 list.count                     // 1
-list[0]                        // "Swift"
+list[0]                        // "Swifty"
 
-list.remove(atIndex: 0)        // "Swift"
+list.remove(atIndex: 0)        // "Swifty"
 list.count                     // 0
 
 let linkedList: LinkedList<Int> = [1, 2, 3, 4] // [1, 2, 3, 4]
@@ -281,7 +282,7 @@ linkedList.count               // 4
 linkedList[0]                  // 1
 
 // Infer the type from the array
-let listArrayLiteral2: LinkedList = ["Swift", "Algorithm", "Club"]
-listArrayLiteral2.count        // 3
-listArrayLiteral2[0]           // "Swift"
-listArrayLiteral2.removeLast() // "Club"
+let listArrayLiteral2: LinkedList? = ["Swift", "Algorithm", "Club"]
+listArrayLiteral2?.count        // 3
+listArrayLiteral2?[0]           // "Swift"
+listArrayLiteral2?.removeLast()  // "Club"

--- a/Linked List/LinkedList.playground/Contents.swift
+++ b/Linked List/LinkedList.playground/Contents.swift
@@ -282,7 +282,7 @@ linkedList.count               // 4
 linkedList[0]                  // 1
 
 // Infer the type from the array
-let listArrayLiteral2: LinkedList? = ["Swift", "Algorithm", "Club"]
-listArrayLiteral2?.count        // 3
-listArrayLiteral2?[0]           // "Swift"
-listArrayLiteral2?.removeLast()  // "Club"
+let listArrayLiteral2: LinkedList = ["Swift", "Algorithm", "Club"]
+listArrayLiteral2.count        // 3
+listArrayLiteral2[0]           // "Swift"
+listArrayLiteral2.removeLast()  // "Club"

--- a/Linked List/LinkedList.swift
+++ b/Linked List/LinkedList.swift
@@ -71,7 +71,8 @@ public final class LinkedList<T> {
         self.append(newNode)
     }
     
-    public func append(_ newNode: Node) {
+    public func append(_ node: Node) {
+        let newNode = Node(value: node.value)
         if let lastNode = last {
             newNode.previous = lastNode
             lastNode.next = newNode
@@ -102,9 +103,9 @@ public final class LinkedList<T> {
         self.insert(newNode, atIndex: index)
     }
     
-    public func insert(_ newNode: Node, atIndex index: Int) {
+    public func insert(_ node: Node, atIndex index: Int) {
         let (prev, next) = nodesBeforeAndAfter(index: index)
-        
+        let newNode = Node(value: node.value)
         newNode.previous = prev
         newNode.next = next
         prev?.next = newNode


### PR DESCRIPTION
This PR address 2 issues in the Linked List files:

- The playground had few wrong comments about the expected output of the statements
- The implementation of the Linked List has a logical error where a `Node` is used as is when passed to the `append` or `insert` functions. The correct way of implementing such functions is to ALWAYS copy the node's value into a new node, and then insert the new node into the data structure.

Without the second fix, a simple statement like `list.append(list.first)` would crash the playground if the list has more than 1 node (`last.next` won't be `nil` in this case)