### PR TITLE
Fix error while trying to run swiftlint

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -17,8 +17,8 @@ disabled_rules:
 custom_rules:
   smiley_face:
     name: "Smiley Face"
-    regex: "(\:\))"
-    match_kinds: 
+    regex: '( :\))'
+    match_kinds:
       - comment
       - string
     message: "A closing parenthesis smiley :) creates a half-hearted smile, and thus is not preferred. Use :]"


### PR DESCRIPTION
Fix "found unknown escape character" while trying to run swiftlint 0.18.1

Also updated the smiley face regex check to have a space before the colon so that it doesn't match the following line: 
fatalError("init(coder:) has not been implemented")


### Checklist

- [x] I've looked at the [contribution guidelines](https://github.com/raywenderlich/swift-algorithm-club/blob/master/.github/CONTRIBUTING.md).
- [x] This pull request is complete and ready for review.

### Description

<!-- In a short paragraph, describe the PR --> 
Fixes the following error while trying to run swiftlint:
error: scanner: while parsing a quoted scalar in line 20, column 12
found unknown escape character:
    regex: "(\:\))"
