### PR TITLE
Add hashed heap data structure

### DIFF
--- a/Hashed Heap/HashedHeap.swift
+++ b/Hashed Heap/HashedHeap.swift
@@ -31,13 +31,13 @@ public struct HashedHeap<T: Hashable> {
     /// - Complexity: O(n)
     public init(array: [T], sort: @escaping (T, T) -> Bool) {
         isOrderedBefore = sort
-        buildHeap(fromArray: array)
+        build(from: array)
     }
 
     /// Converts an array to a max-heap or min-heap in a bottom-up manner.
     ///
     /// - Complexity: O(n)
-    private mutating func buildHeap(fromArray array: [T]) {
+    private mutating func build(from array: [T]) {
         elements = array
         for index in elements.indices {
             indices[elements[index]] = index
@@ -96,12 +96,12 @@ public struct HashedHeap<T: Hashable> {
     /// Replaces an element in the hash.
     ///
     /// In a max-heap, the new element should be larger than the old one; in a min-heap it should be smaller.
-    public mutating func replace(index i: Int, value: T) {
-        guard i < elements.count else { return }
+    public mutating func replace(_ value: T, at index: Int) {
+        guard index < elements.count else { return }
 
-        assert(isOrderedBefore(value, elements[i]))
-        set(value, at: i)
-        shiftUp(i)
+        assert(isOrderedBefore(value, elements[index]))
+        set(value, at: index)
+        shiftUp(index)
     }
 
     /// Removes the root node from the heap.
@@ -130,7 +130,7 @@ public struct HashedHeap<T: Hashable> {
     /// You need to know the node's index, which may actually take O(n) steps to find.
     ///
     /// - Complexity: O(log n).
-    public mutating func removeAt(_ index: Int) -> T? {
+    public mutating func remove(at index: Int) -> T? {
         guard index < elements.count else { return nil }
 
         let size = elements.count - 1
@@ -158,12 +158,12 @@ public struct HashedHeap<T: Hashable> {
     mutating func shiftUp(_ index: Int) {
         var childIndex = index
         let child = elements[childIndex]
-        var parentIndex = self.parentIndex(ofIndex: childIndex)
+        var parentIndex = self.parentIndex(of: childIndex)
 
         while childIndex > 0 && isOrderedBefore(child, elements[parentIndex]) {
             set(elements[parentIndex], at: childIndex)
             childIndex = parentIndex
-            parentIndex = self.parentIndex(ofIndex: childIndex)
+            parentIndex = self.parentIndex(of: childIndex)
         }
 
         set(child, at: childIndex)
@@ -178,7 +178,7 @@ public struct HashedHeap<T: Hashable> {
         var parentIndex = index
 
         while true {
-            let leftChildIndex = self.leftChildIndex(ofIndex: parentIndex)
+            let leftChildIndex = self.leftChildIndex(of: parentIndex)
             let rightChildIndex = leftChildIndex + 1
 
             // Figure out which comes first if we order them by the sort function:
@@ -208,7 +208,7 @@ public struct HashedHeap<T: Hashable> {
 
     /// Swap two elements in the heap and update the indices hash.
     private mutating func swapAt(_ i: Int, _ j: Int) {
-        swap(&elements[i], &elements[j])
+        elements.swapAt(i, j)
         indices[elements[i]] = i
         indices[elements[j]] = j
     }
@@ -217,23 +217,23 @@ public struct HashedHeap<T: Hashable> {
     ///
     /// - Note: The element at index 0 is the root of the tree and has no parent.
     @inline(__always)
-    func parentIndex(ofIndex i: Int) -> Int {
-        return (i - 1) / 2
+    func parentIndex(of index: Int) -> Int {
+        return (index - 1) / 2
     }
 
     /// Returns the index of the left child of the element at index i.
     ///
     /// - Note: this index can be greater than the heap size, in which case there is no left child.
     @inline(__always)
-    func leftChildIndex(ofIndex i: Int) -> Int {
-        return 2*i + 1
+    func leftChildIndex(of index: Int) -> Int {
+        return 2*index + 1
     }
 
     /// Returns the index of the right child of the element at index i.
     ///
     /// - Note: this index can be greater than the heap size, in which case there is no right child.
     @inline(__always)
-    func rightChildIndex(ofIndex i: Int) -> Int {
-        return 2*i + 2
+    func rightChildIndex(of index: Int) -> Int {
+        return 2*index + 2
     }
 }

--- a/Hashed Heap/HashedHeap.swift
+++ b/Hashed Heap/HashedHeap.swift
@@ -1,0 +1,239 @@
+// Written by Alejandro Isaza. Adapted from heap implementation written by Kevin Randrup and Matthijs Hollemans.
+
+/// Heap with an index hash map (dictionary) to speed up lookups by value.
+///
+/// A heap keeps elements ordered in a binary tree without the use of pointers. A hashed heap does that as well as
+/// having amortized constant lookups by value. This is used in the A* and other heuristic search alogirhtms to achieve
+/// optimal perfomrance.
+public struct HashedHeap<T: Hashable> {
+    /// The array that stores the heap's nodes.
+    private(set) var elements = [T]()
+
+    /// Hash mapping from elements to indices in the `elements` array.
+    private(set) var indices = [T: Int]()
+
+    /// Determines whether this is a max-heap (>) or min-heap (<).
+    fileprivate var isOrderedBefore: (T, T) -> Bool
+
+    /// Creates an empty hashed heap.
+    ///
+    /// The sort function determines whether this is a min-heap or max-heap. For integers, > makes a max-heap, < makes
+    /// a min-heap.
+    public init(sort: @escaping (T, T) -> Bool) {
+        isOrderedBefore = sort
+    }
+
+    /// Creates a hashed heap from an array.
+    ///
+    /// The order of the array does not matter; the elements are inserted into the heap in the order determined by the
+    /// sort function.
+    ///
+    /// - Complexity: O(n)
+    public init(array: [T], sort: @escaping (T, T) -> Bool) {
+        isOrderedBefore = sort
+        buildHeap(fromArray: array)
+    }
+
+    /// Converts an array to a max-heap or min-heap in a bottom-up manner.
+    ///
+    /// - Complexity: O(n)
+    private mutating func buildHeap(fromArray array: [T]) {
+        elements = array
+        for index in elements.indices {
+            indices[elements[index]] = index
+        }
+
+        for i in stride(from: (elements.count/2 - 1), through: 0, by: -1) {
+            shiftDown(i, heapSize: elements.count)
+        }
+    }
+
+    /// Whether the heap is empty.
+    public var isEmpty: Bool {
+        return elements.isEmpty
+    }
+
+    /// The number of elements in the heap.
+    public var count: Int {
+        return elements.count
+    }
+
+    /// Returns the index of the given element.
+    ///
+    /// This is the operation that a hashed heap optimizes in compassion with a normal heap. In a normal heap this
+    /// would take O(n), but for the hashed heap this takes amortized constatn time.
+    ///
+    /// - Complexity: Amortized constant
+    public func index(of element: T) -> Int? {
+        return indices[element]
+    }
+
+    /// Returns the maximum value in the heap (for a max-heap) or the minimum value (for a min-heap).
+    ///
+    /// - Complexity: O(1)
+    public func peek() -> T? {
+        return elements.first
+    }
+
+    /// Adds a new value to the heap.
+    ///
+    /// This reorders the heap so that the max-heap or min-heap property still holds.
+    ///
+    /// - Complexity: O(log n)
+    public mutating func insert(_ value: T) {
+        elements.append(value)
+        indices[value] = elements.count - 1
+        shiftUp(elements.count - 1)
+    }
+
+    /// Adds new values to the heap.
+    public mutating func insert<S: Sequence>(_ sequence: S) where S.Iterator.Element == T {
+        for value in sequence {
+            insert(value)
+        }
+    }
+
+    /// Replaces an element in the hash.
+    ///
+    /// In a max-heap, the new element should be larger than the old one; in a min-heap it should be smaller.
+    public mutating func replace(index i: Int, value: T) {
+        guard i < elements.count else { return }
+
+        assert(isOrderedBefore(value, elements[i]))
+        set(value, at: i)
+        shiftUp(i)
+    }
+
+    /// Removes the root node from the heap.
+    ///
+    /// For a max-heap, this is the maximum value; for a min-heap it is the minimum value.
+    ///
+    /// - Complexity: O(log n)
+    @discardableResult
+    public mutating func remove() -> T? {
+        if elements.isEmpty {
+            return nil
+        } else if elements.count == 1 {
+            return removeLast()
+        } else {
+            // Use the last node to replace the first one, then fix the heap by
+            // shifting this new first node into its proper position.
+            let value = elements[0]
+            set(removeLast(), at: 0)
+            shiftDown()
+            return value
+        }
+    }
+
+    /// Removes an arbitrary node from the heap.
+    ///
+    /// You need to know the node's index, which may actually take O(n) steps to find.
+    ///
+    /// - Complexity: O(log n).
+    public mutating func removeAt(_ index: Int) -> T? {
+        guard index < elements.count else { return nil }
+
+        let size = elements.count - 1
+        if index != size {
+            swapAt(index, size)
+            shiftDown(index, heapSize: size)
+            shiftUp(index)
+        }
+        return removeLast()
+    }
+
+    /// Removes the last element from the heap.
+    ///
+    /// - Complexity: O(1)
+    public mutating func removeLast() -> T {
+        guard let value = elements.last else {
+            preconditionFailure("Trying to remove element from empty heap")
+        }
+        indices[value] = nil
+        return elements.removeLast()
+    }
+
+    /// Takes a child node and looks at its parents; if a parent is not larger (max-heap) or not smaller (min-heap)
+    /// than the child, we exchange them.
+    mutating func shiftUp(_ index: Int) {
+        var childIndex = index
+        let child = elements[childIndex]
+        var parentIndex = self.parentIndex(ofIndex: childIndex)
+
+        while childIndex > 0 && isOrderedBefore(child, elements[parentIndex]) {
+            set(elements[parentIndex], at: childIndex)
+            childIndex = parentIndex
+            parentIndex = self.parentIndex(ofIndex: childIndex)
+        }
+
+        set(child, at: childIndex)
+    }
+
+    mutating func shiftDown() {
+        shiftDown(0, heapSize: elements.count)
+    }
+
+    /// Looks at a parent node and makes sure it is still larger (max-heap) or smaller (min-heap) than its childeren.
+    mutating func shiftDown(_ index: Int, heapSize: Int) {
+        var parentIndex = index
+
+        while true {
+            let leftChildIndex = self.leftChildIndex(ofIndex: parentIndex)
+            let rightChildIndex = leftChildIndex + 1
+
+            // Figure out which comes first if we order them by the sort function:
+            // the parent, the left child, or the right child. If the parent comes
+            // first, we're done. If not, that element is out-of-place and we make
+            // it "float down" the tree until the heap property is restored.
+            var first = parentIndex
+            if leftChildIndex < heapSize && isOrderedBefore(elements[leftChildIndex], elements[first]) {
+                first = leftChildIndex
+            }
+            if rightChildIndex < heapSize && isOrderedBefore(elements[rightChildIndex], elements[first]) {
+                first = rightChildIndex
+            }
+            if first == parentIndex { return }
+
+            swapAt(parentIndex, first)
+            parentIndex = first
+        }
+    }
+
+    /// Replaces an element in the heap and updates the indices hash.
+    private mutating func set(_ newValue: T, at index: Int) {
+        indices[elements[index]] = nil
+        elements[index] = newValue
+        indices[newValue] = index
+    }
+
+    /// Swap two elements in the heap and update the indices hash.
+    private mutating func swapAt(_ i: Int, _ j: Int) {
+        swap(&elements[i], &elements[j])
+        indices[elements[i]] = i
+        indices[elements[j]] = j
+    }
+
+    /// Returns the index of the parent of the element at index i.
+    ///
+    /// - Note: The element at index 0 is the root of the tree and has no parent.
+    @inline(__always)
+    func parentIndex(ofIndex i: Int) -> Int {
+        return (i - 1) / 2
+    }
+
+    /// Returns the index of the left child of the element at index i.
+    ///
+    /// - Note: this index can be greater than the heap size, in which case there is no left child.
+    @inline(__always)
+    func leftChildIndex(ofIndex i: Int) -> Int {
+        return 2*i + 1
+    }
+
+    /// Returns the index of the right child of the element at index i.
+    ///
+    /// - Note: this index can be greater than the heap size, in which case there is no right child.
+    @inline(__always)
+    func rightChildIndex(ofIndex i: Int) -> Int {
+        return 2*i + 2
+    }
+}

--- a/Hashed Heap/README.markdown
+++ b/Hashed Heap/README.markdown
@@ -1,0 +1,11 @@
+# Hashed Heap
+
+A hashed heap is a [heap](../Heap/) with a hash map (also known as a dictionary) to speed up lookup of elements by value. This combination doesn't compromize on time performance but requires extra storage for the hash map. This is mainly used for heuristic search algorihms, in particular A*.
+
+## The code
+
+See [HashedHeap.swift](HashedHeap.swift) for the implementation. See [Heap](../Heap/) for a detailed explanation of the basic heap implementation.
+
+## See also
+
+[Heap on Wikipedia](https://en.wikipedia.org/wiki/Heap_%28data_structure%29)

--- a/Hashed Heap/Tests/Hashed Heap Tests.xcodeproj/project.pbxproj
+++ b/Hashed Heap/Tests/Hashed Heap Tests.xcodeproj/project.pbxproj
@@ -1,0 +1,268 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		7B80C3FC1C77A658003CECC7 /* HashedHeap.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B80C3FB1C77A658003CECC7 /* HashedHeap.swift */; };
+		7B80C3FE1C77A65E003CECC7 /* HashedHeapTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B80C3FD1C77A65E003CECC7 /* HashedHeapTests.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		7B2BBC801C779D720067B71D /* Hashed Heap Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Hashed Heap Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		7B2BBC941C779E7B0067B71D /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = SOURCE_ROOT; };
+		7B80C3FB1C77A658003CECC7 /* HashedHeap.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = HashedHeap.swift; path = ../HashedHeap.swift; sourceTree = SOURCE_ROOT; };
+		7B80C3FD1C77A65E003CECC7 /* HashedHeapTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HashedHeapTests.swift; sourceTree = SOURCE_ROOT; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		7B2BBC7D1C779D720067B71D /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		7B2BBC681C779D710067B71D = {
+			isa = PBXGroup;
+			children = (
+				7B2BBC831C779D720067B71D /* Tests */,
+				7B2BBC721C779D710067B71D /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		7B2BBC721C779D710067B71D /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				7B2BBC801C779D720067B71D /* Hashed Heap Tests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		7B2BBC831C779D720067B71D /* Tests */ = {
+			isa = PBXGroup;
+			children = (
+				7B80C3FB1C77A658003CECC7 /* HashedHeap.swift */,
+				7B80C3FD1C77A65E003CECC7 /* HashedHeapTests.swift */,
+				7B2BBC941C779E7B0067B71D /* Info.plist */,
+			);
+			name = Tests;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		7B2BBC7F1C779D720067B71D /* Hashed Heap Tests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 7B2BBC8C1C779D720067B71D /* Build configuration list for PBXNativeTarget "Hashed Heap Tests" */;
+			buildPhases = (
+				7B2BBC7C1C779D720067B71D /* Sources */,
+				7B2BBC7D1C779D720067B71D /* Frameworks */,
+				7B2BBC7E1C779D720067B71D /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "Hashed Heap Tests";
+			productName = TestsTests;
+			productReference = 7B2BBC801C779D720067B71D /* Hashed Heap Tests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		7B2BBC691C779D710067B71D /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastSwiftUpdateCheck = 0720;
+				LastUpgradeCheck = 0800;
+				ORGANIZATIONNAME = "Swift Algorithm Club";
+				TargetAttributes = {
+					7B2BBC7F1C779D720067B71D = {
+						CreatedOnToolsVersion = 7.2;
+						LastSwiftMigration = 0820;
+					};
+				};
+			};
+			buildConfigurationList = 7B2BBC6C1C779D710067B71D /* Build configuration list for PBXProject "Hashed Heap Tests" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = English;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 7B2BBC681C779D710067B71D;
+			productRefGroup = 7B2BBC721C779D710067B71D /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				7B2BBC7F1C779D720067B71D /* Hashed Heap Tests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		7B2BBC7E1C779D720067B71D /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		7B2BBC7C1C779D720067B71D /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				7B80C3FE1C77A65E003CECC7 /* HashedHeapTests.swift in Sources */,
+				7B80C3FC1C77A658003CECC7 /* HashedHeap.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		7B2BBC871C779D720067B71D /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "-";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = macosx;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		7B2BBC881C779D720067B71D /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "-";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = macosx;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+			};
+			name = Release;
+		};
+		7B2BBC8D1C779D720067B71D /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
+				INFOPLIST_FILE = Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = swift.algorithm.club.Tests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 3.0;
+			};
+			name = Debug;
+		};
+		7B2BBC8E1C779D720067B71D /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
+				INFOPLIST_FILE = Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = swift.algorithm.club.Tests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 3.0;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		7B2BBC6C1C779D710067B71D /* Build configuration list for PBXProject "Hashed Heap Tests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				7B2BBC871C779D720067B71D /* Debug */,
+				7B2BBC881C779D720067B71D /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		7B2BBC8C1C779D720067B71D /* Build configuration list for PBXNativeTarget "Hashed Heap Tests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				7B2BBC8D1C779D720067B71D /* Debug */,
+				7B2BBC8E1C779D720067B71D /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 7B2BBC691C779D710067B71D /* Project object */;
+}

--- a/Hashed Heap/Tests/Hashed Heap Tests.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/Hashed Heap/Tests/Hashed Heap Tests.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:Tests.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/Hashed Heap/Tests/Hashed Heap Tests.xcodeproj/xcshareddata/xcschemes/Hashed Heap Tests.xcscheme
+++ b/Hashed Heap/Tests/Hashed Heap Tests.xcodeproj/xcshareddata/xcschemes/Hashed Heap Tests.xcscheme
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0800"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "7B2BBC7F1C779D720067B71D"
+               BuildableName = "Hashed Heap Tests.xctest"
+               BlueprintName = "Hashed Heap Tests"
+               ReferencedContainer = "container:Hashed Heap Tests.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "7B2BBC7F1C779D720067B71D"
+            BuildableName = "Tests.xctest"
+            BlueprintName = "Tests"
+            ReferencedContainer = "container:Tests.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Hashed Heap/Tests/HashedHeapTests.swift
+++ b/Hashed Heap/Tests/HashedHeapTests.swift
@@ -1,0 +1,88 @@
+import Foundation
+import XCTest
+
+private struct Message: Hashable {
+    let text: String
+    let priority: Int
+
+    var hashValue: Int {
+        return text.hashValue
+    }
+
+    static func == (lhs: Message, rhs: Message) -> Bool {
+        return lhs.text == rhs.text
+    }
+
+    static func < (m1: Message, m2: Message) -> Bool {
+        return m1.priority < m2.priority
+    }
+}
+
+class HashedHeapTest: XCTestCase {
+    func testEmpty() {
+        var queue = HashedHeap<Message>(sort: <)
+        XCTAssertTrue(queue.isEmpty)
+        XCTAssertEqual(queue.count, 0)
+        XCTAssertNil(queue.peek())
+        XCTAssertNil(queue.remove())
+    }
+
+    func testOneElement() {
+        var queue = HashedHeap<Message>(sort: <)
+
+        queue.insert(Message(text: "hello", priority: 100))
+        XCTAssertFalse(queue.isEmpty)
+        XCTAssertEqual(queue.count, 1)
+        XCTAssertEqual(queue.peek()!.priority, 100)
+
+        let result = queue.remove()
+        XCTAssertEqual(result!.priority, 100)
+        XCTAssertTrue(queue.isEmpty)
+        XCTAssertEqual(queue.count, 0)
+        XCTAssertNil(queue.peek())
+    }
+
+    func testTwoElementsInOrder() {
+        var queue = HashedHeap<Message>(sort: <)
+
+        queue.insert(Message(text: "hello", priority: 100))
+        queue.insert(Message(text: "world", priority: 200))
+        XCTAssertFalse(queue.isEmpty)
+        XCTAssertEqual(queue.count, 2)
+        XCTAssertEqual(queue.peek()!.priority, 100)
+
+        let result1 = queue.remove()
+        XCTAssertEqual(result1!.priority, 100)
+        XCTAssertFalse(queue.isEmpty)
+        XCTAssertEqual(queue.count, 1)
+        XCTAssertEqual(queue.peek()!.priority, 200)
+
+        let result2 = queue.remove()
+        XCTAssertEqual(result2!.priority, 200)
+        XCTAssertTrue(queue.isEmpty)
+        XCTAssertEqual(queue.count, 0)
+        XCTAssertNil(queue.peek())
+    }
+
+    func testTwoElementsOutOfOrder() {
+        var queue = HashedHeap<Message>(sort: <)
+
+        queue.insert(Message(text: "world", priority: 200))
+        queue.insert(Message(text: "hello", priority: 100))
+        XCTAssertFalse(queue.isEmpty)
+        XCTAssertEqual(queue.count, 2)
+        XCTAssertEqual(queue.peek()!.priority, 100)
+
+        let result1 = queue.remove()
+        XCTAssertEqual(result1!.priority, 100)
+        XCTAssertFalse(queue.isEmpty)
+        XCTAssertEqual(queue.count, 1)
+        XCTAssertEqual(queue.peek()!.priority, 200)
+
+        let result2 = queue.remove()
+        XCTAssertEqual(result2!.priority, 200)
+        XCTAssertTrue(queue.isEmpty)
+        XCTAssertEqual(queue.count, 0)
+        XCTAssertNil(queue.peek())
+    }
+}

--- a/Hashed Heap/Tests/Info.plist
+++ b/Hashed Heap/Tests/Info.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/swift-algorithm-club.xcworkspace/contents.xcworkspacedata
+++ b/swift-algorithm-club.xcworkspace/contents.xcworkspacedata
@@ -1070,6 +1070,29 @@
       </FileRef>
    </Group>
    <Group
+      location = "group:Hashed Heap"
+      name = "Hashed Heap">
+      <FileRef
+         location = "group:HashedHeap.swift">
+      </FileRef>
+      <FileRef
+         location = "group:README.markdown">
+      </FileRef>
+      <Group
+         location = "group:Tests"
+         name = "Tests">
+         <FileRef
+            location = "group:Info.plist">
+         </FileRef>
+         <FileRef
+            location = "group:HashedHeapTests.swift">
+         </FileRef>
+         <FileRef
+            location = "group:/Users/al/dev/swift-algorithm-club/Hashed Heap/Tests/Hashed Heap Tests.xcodeproj">
+         </FileRef>
+      </Group>
+   </Group>
+   <Group
       location = "group:HaversineDistance"
       name = "HaversineDistance">
       <FileRef


### PR DESCRIPTION
### Checklist

- [x] I've looked at the [contribution guidelines](https://github.com/raywenderlich/swift-algorithm-club/blob/master/.github/CONTRIBUTING.md).
- [x] This pull request is complete and ready for review.

### Description

Even though there already is a PR for an A* implementation, that PR implements it in O(bN^2) instead of the optimal O(bn). This data structure is the necessary building block for an optimal implementation. It is just a variation on the existing regular heap, but adding a hash map for fast lookups by value.

