### PR TITLE
removes redundant case let ? statements from workspace

### DIFF
--- a/Binary Search Tree/README.markdown
+++ b/Binary Search Tree/README.markdown
@@ -267,7 +267,7 @@ Searching is a recursive process, but you can also implement it with a simple lo
 ```swift
   public func search(value: T) -> BinarySearchTree? {
     var node: BinarySearchTree? = self
-    while case let n? = node {
+    while let n = node {
       if value < n.value {
         node = n.left
       } else if value > n.value {
@@ -391,7 +391,7 @@ We also need a function that returns the minimum and maximum of a node:
 ```swift
   public func minimum() -> BinarySearchTree {
     var node = self
-    while case let next? = node.left {
+    while let next = node.left {
       node = next
     }
     return node
@@ -399,7 +399,7 @@ We also need a function that returns the minimum and maximum of a node:
 
   public func maximum() -> BinarySearchTree {
     var node = self
-    while case let next? = node.right {
+    while let next = node.right {
       node = next
     }
     return node
@@ -471,7 +471,7 @@ You can also calculate the *depth* of a node, which is the distance to the root.
   public func depth() -> Int {
     var node = self
     var edges = 0
-    while case let parent? = node.parent {
+    while let parent = node.parent {
       node = parent
       edges += 1
     }
@@ -503,7 +503,7 @@ The `predecessor()` function returns the node whose value precedes the current v
       return left.maximum()
     } else {
       var node = self
-      while case let parent? = node.parent {
+      while let parent = node.parent {
         if parent.value < value { return parent }
         node = parent
       }
@@ -524,7 +524,7 @@ The code for `successor()` works the same way but mirrored:
       return right.minimum()
     } else {
       var node = self
-      while case let parent? = node.parent {
+      while let parent = node.parent {
         if parent.value > value { return parent }
         node = parent
       }

--- a/Binary Search Tree/Solution 1/BinarySearchTree.playground/Sources/BinarySearchTree.swift
+++ b/Binary Search Tree/Solution 1/BinarySearchTree.playground/Sources/BinarySearchTree.swift
@@ -155,7 +155,7 @@ extension BinarySearchTree {
   */
   public func search(value: T) -> BinarySearchTree? {
     var node: BinarySearchTree? = self
-    while case let n? = node {
+    while let n = node {
       if value < n.value {
         node = n.left
       } else if value > n.value {
@@ -189,7 +189,7 @@ extension BinarySearchTree {
   */
   public func minimum() -> BinarySearchTree {
     var node = self
-    while case let next? = node.left {
+    while let next = node.left {
       node = next
     }
     return node
@@ -200,7 +200,7 @@ extension BinarySearchTree {
   */
   public func maximum() -> BinarySearchTree {
     var node = self
-    while case let next? = node.right {
+    while let next = node.right {
       node = next
     }
     return node
@@ -213,7 +213,7 @@ extension BinarySearchTree {
   public func depth() -> Int {
     var node = self
     var edges = 0
-    while case let parent? = node.parent {
+    while let parent = node.parent {
       node = parent
       edges += 1
     }
@@ -240,7 +240,7 @@ extension BinarySearchTree {
       return left.maximum()
     } else {
       var node = self
-      while case let parent? = node.parent {
+      while let parent = node.parent {
         if parent.value < value { return parent }
         node = parent
       }
@@ -256,7 +256,7 @@ extension BinarySearchTree {
       return right.minimum()
     } else {
       var node = self
-      while case let parent? = node.parent {
+      while let parent = node.parent {
         if parent.value > value { return parent }
         node = parent
       }

--- a/LRU Cache/LRUCache.playground/Sources/LinkedList.swift
+++ b/LRU Cache/LRUCache.playground/Sources/LinkedList.swift
@@ -26,7 +26,7 @@ public final class LinkedList<T> {
 
     public var last: Node? {
         if var node = head {
-            while case let next? = node.next {
+            while let next = node.next {
                 node = next
             }
             return node
@@ -38,7 +38,7 @@ public final class LinkedList<T> {
     public var count: Int {
         if var node = head {
             var c = 1
-            while case let next? = node.next {
+            while let next = node.next {
                 node = next
                 c += 1
             }

--- a/Linked List/LinkedList.swift
+++ b/Linked List/LinkedList.swift
@@ -26,7 +26,7 @@ public final class LinkedList<T> {
 
     public var last: Node? {
         if var node = head {
-            while case let next? = node.next {
+            while let next = node.next {
                 node = next
             }
             return node
@@ -38,7 +38,7 @@ public final class LinkedList<T> {
     public var count: Int {
         if var node = head {
             var c = 1
-            while case let next? = node.next {
+            while let next = node.next {
                 node = next
                 c += 1
             }

--- a/Linked List/README.markdown
+++ b/Linked List/README.markdown
@@ -109,7 +109,7 @@ Let's also add a property that gives you the last node in the list. This is wher
 ```swift
   public var last: Node? {
     if var node = head {
-      while case let next? = node.next {
+      while let next = node.next {
         node = next
       }
       return node
@@ -121,7 +121,7 @@ Let's also add a property that gives you the last node in the list. This is wher
 
 If you're new to Swift, you've probably seen `if let` but maybe not `if var`. It does the same thing -- it unwraps the `head` optional and puts the result in a new local variable named `node`. The difference is that `node` is not a constant but an actual variable, so we can change it inside the loop.
 
-The loop also does some Swift magic. The `while case let next? = node.next` bit keeps looping until `node.next` is nil. You could have written this as follows:
+The loop also does some Swift magic. The `while let next = node.next` bit keeps looping until `node.next` is nil. You could have written this as follows:
 
 ```swift
       var node: Node? = head
@@ -198,7 +198,7 @@ Let's add a method to count how many nodes are in the list. This will look very 
   public var count: Int {
     if var node = head {
       var c = 1
-      while case let next? = node.next {
+      while let next = node.next {
         node = next
         c += 1
       }

--- a/Threaded Binary Tree/ThreadedBinaryTree.playground/Sources/ThreadedBinaryTree.swift
+++ b/Threaded Binary Tree/ThreadedBinaryTree.playground/Sources/ThreadedBinaryTree.swift
@@ -217,7 +217,7 @@ extension ThreadedBinaryTree {
   */
   public func search(_ value: T) -> ThreadedBinaryTree? {
     var node: ThreadedBinaryTree? = self
-    while case let n? = node {
+    while let n = node {
       if value < n.value {
         node = n.left
       } else if value > n.value {
@@ -252,7 +252,7 @@ extension ThreadedBinaryTree {
   */
   public func minimum() -> ThreadedBinaryTree {
     var node = self
-    while case let next? = node.left {
+    while let next = node.left {
       node = next
     }
     return node
@@ -263,7 +263,7 @@ extension ThreadedBinaryTree {
   */
   public func maximum() -> ThreadedBinaryTree {
     var node = self
-    while case let next? = node.right {
+    while let next = node.right {
       node = next
     }
     return node
@@ -276,7 +276,7 @@ extension ThreadedBinaryTree {
   public func depth() -> Int {
     var node = self
     var edges = 0
-    while case let parent? = node.parent {
+    while let parent = node.parent {
       node = parent
       edges += 1
     }


### PR DESCRIPTION
<!-- Thanks for contributing to the SAC! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist

- [x ] I've looked at the [contribution guidelines](https://github.com/raywenderlich/swift-algorithm-club/blob/master/.github/CONTRIBUTING.md).
- [x ] This pull request is complete and ready for review.

### Description

<!-- In a short paragraph, describe the PR --> 

This set of changes removes redundant use of the optional binding ```swift case let _?``` statement. It also updates the matching explanations. 

before 
```swift
while case let next? = node.next { ...  }
```
after
```swift
 while let next = node.next { ...  }
```