### PR TITLE
fix what seems to be a mistake with `k > n/2` in " Selection Sampling"

### DIFF
--- a/Selection Sampling/README.markdown
+++ b/Selection Sampling/README.markdown
@@ -193,7 +193,7 @@ print(output.count)
 
 The performance of this second algorithm is **O(n)** as it may require a pass through the entire input array.
 
-> **Note:** If `k > n/2`, then it's more efficient to do it the other way around and choose `n - k` items to remove.  The returned itemsTT won't be perfectly shuffled.
+> **Note:** If `k > n/2`, then it's more efficient to do it the other way around and choose `n - k` items to remove.  The returned items won't be perfectly shuffled.
 
 Based on code from Algorithm Alley, Dr. Dobb's Magazine, October 1993.
 

--- a/Selection Sampling/README.markdown
+++ b/Selection Sampling/README.markdown
@@ -193,7 +193,7 @@ print(output.count)
 
 The performance of this second algorithm is **O(n)** as it may require a pass through the entire input array.
 
-> **Note:** If `k > n/2`, then it's more efficient to do it the other way around and choose `k` items to remove.
+> **Note:** If `k > n/2`, then it's more efficient to do it the other way around and choose `n - k` items to remove.
 
 Based on code from Algorithm Alley, Dr. Dobb's Magazine, October 1993.
 

--- a/Selection Sampling/README.markdown
+++ b/Selection Sampling/README.markdown
@@ -193,7 +193,7 @@ print(output.count)
 
 The performance of this second algorithm is **O(n)** as it may require a pass through the entire input array.
 
-> **Note:** If `k > n/2`, then it's more efficient to do it the other way around and choose `n - k` items to remove.
+> **Note:** If `k > n/2`, then it's more efficient to do it the other way around and choose `n - k` items to remove.  This will however not perfectly shuffle the items not removed.
 
 Based on code from Algorithm Alley, Dr. Dobb's Magazine, October 1993.
 

--- a/Selection Sampling/README.markdown
+++ b/Selection Sampling/README.markdown
@@ -193,7 +193,7 @@ print(output.count)
 
 The performance of this second algorithm is **O(n)** as it may require a pass through the entire input array.
 
-> **Note:** If `k > n/2`, then it's more efficient to do it the other way around and choose `n - k` items to remove.  This will however not perfectly shuffle the items not removed.
+> **Note:** If `k > n/2`, then it's more efficient to do it the other way around and choose `n - k` items to remove.  The returned itemsTT won't be perfectly shuffled.
 
 Based on code from Algorithm Alley, Dr. Dobb's Magazine, October 1993.
 


### PR DESCRIPTION
<!-- Thanks for contributing to the SAC! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist

- [x] I've looked at the [contribution guidelines](https://github.com/raywenderlich/swift-algorithm-club/blob/master/.github/CONTRIBUTING.md).
- [x] This pull request is complete and ready for review.

### Description

The note at the end of "Selection Sampling" about the case when k is larger than half seems it would select only `n - k` items and not `k`.
