### PR TITLE
Avoid integer overflow in LCM calculation

### DIFF
--- a/GCD/GCD.playground/Contents.swift
+++ b/GCD/GCD.playground/Contents.swift
@@ -32,7 +32,7 @@ func gcd(m: Int, _ n: Int) -> Int {
 */
 
 func lcm(_ m: Int, _ n: Int) -> Int {
-  return m*n / gcd(m, n)
+  return m / gcd(m, n) * n // we divide before multiplying to avoid integer overflow
 }
 
 gcd(52, 39)       // 13

--- a/GCD/GCD.swift
+++ b/GCD/GCD.swift
@@ -30,5 +30,5 @@ func gcd(_ a: Int, _ b: Int) -> Int {
   Returns the least common multiple of two numbers.
 */
 func lcm(_ m: Int, _ n: Int) -> Int {
-  return m*n / gcd(m, n)
+  return m / gcd(m, n) * n
 }

--- a/GCD/README.markdown
+++ b/GCD/README.markdown
@@ -102,7 +102,7 @@ In code:
 
 ```swift
 func lcm(_ m: Int, _ n: Int) -> Int {
-  return m*n / gcd(m, n)
+  return m / gcd(m, n) * n
 }
 ```
 


### PR DESCRIPTION
<!-- Thanks for contributing to the SAC! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist

- [x] I've looked at the [contribution guidelines](https://github.com/raywenderlich/swift-algorithm-club/blob/master/.github/CONTRIBUTING.md).
- [x] This pull request is complete and ready for review.

### Description

<!-- In a short paragraph, describe the PR --> 

By changing the arithmetic operation order, we can calculate the least common multiplier correctly for larger integers without overflow.