### PR TITLE
Swift 4 syntax update

### DIFF
--- a/Radix Tree/RadixTree.playground/Sources/RadixTree.swift
+++ b/Radix Tree/RadixTree.playground/Sources/RadixTree.swift
@@ -181,10 +181,10 @@ public class RadixTree {
 				else if shared == e.label {
 					currEdge = e
 					var tempIndex = searchStr.startIndex
-					for _ in 1...shared.characters.count {
-						tempIndex = searchStr.characters.index(after: tempIndex)
+					for _ in 1...shared.count {
+						tempIndex = searchStr.index(after: tempIndex)
 					}
-                    searchStr = searchStr.substring(from: tempIndex)
+                    searchStr = String(searchStr[tempIndex...])
 					found = true
 					break
 				}
@@ -192,18 +192,18 @@ public class RadixTree {
 				// If the child's label and the search string share a partial prefix,
 				// then both the label and the search string need to be substringed
 				// and a new branch needs to be created
-				else if shared.characters.count > 0 {
-					var labelIndex = e.label.characters.startIndex
+				else if shared.count > 0 {
+					var labelIndex = e.label.startIndex
 
 					// Create index objects and move them to after the shared prefix
-					for _ in 1...shared.characters.count {
-                        index = searchStr.characters.index(after: index)
-						labelIndex = e.label.characters.index(after: labelIndex)
+					for _ in 1...shared.count {
+                        index = searchStr.index(after: index)
+						labelIndex = e.label.index(after: labelIndex)
 					}
 
 					// Substring both the search string and the label from the shared prefix
-                    searchStr = searchStr.substring(from: index)
-                    e.label = e.label.substring(from: labelIndex)
+                    searchStr = String(searchStr[index...])
+                    e.label = String(e.label[labelIndex...])
 
 					// Create 2 new edges and update parent/children values
 					let newEdge = Edge(e.label)
@@ -266,16 +266,16 @@ public class RadixTree {
 				if shared == c.label {
 					currEdge = c
 					var tempIndex = searchStr.startIndex
-					for _ in 1...shared.characters.count {
-						tempIndex = searchStr.characters.index(after: tempIndex)
+					for _ in 1...shared.count {
+						tempIndex = searchStr.index(after: tempIndex)
 					}
-					searchStr = searchStr.substring(from: tempIndex)
+					searchStr = String(searchStr[tempIndex...])
 					found = true
 					break
 				}
 
 				// If the shared string is empty, go to the next child
-				else if shared.characters.count == 0 {
+				else if shared.count == 0 {
 					continue
 				}
 
@@ -287,7 +287,7 @@ public class RadixTree {
 				// If the search string and the child's label only share some characters,
 				// the string is not in the tree, return false
 				else if shared[shared.startIndex] == c.label[c.label.startIndex] &&
-				  shared.characters.count < c.label.characters.count {
+				  shared.count < c.label.count {
 				  	return false
 				}
 			}
@@ -340,10 +340,10 @@ public class RadixTree {
 				if shared == currEdge.children[c].label {
 					currEdge = currEdge.children[c]
 					var tempIndex = searchStr.startIndex
-					for _ in 1...shared.characters.count {
-						tempIndex = searchStr.characters.index(after: tempIndex)
+					for _ in 1...shared.count {
+						tempIndex = searchStr.index(after: tempIndex)
 					}
-					searchStr = searchStr.substring(from: tempIndex)
+					searchStr = String(searchStr[tempIndex...])
 					found = true
 					break
 				}
@@ -366,13 +366,13 @@ public class RadixTree {
 // i.e. sharedPrefix("court", "coral") -> "co"
 public func sharedPrefix(_ str1: String, _ str2: String) -> String {
 	var temp = ""
-	var c1 = str1.characters.startIndex
-	var c2 = str2.characters.startIndex
-	for _ in 0...min(str1.characters.count-1, str2.characters.count-1) {
+	var c1 = str1.startIndex
+	var c2 = str2.startIndex
+	for _ in 0...min(str1.count-1, str2.count-1) {
 		if str1[c1] == str2[c2] {
 			temp.append( str1[c1] )
-            c1 = str1.characters.index(after:c1)
-            c2 = str2.characters.index(after:c2)
+            c1 = str1.index(after:c1)
+            c2 = str2.index(after:c2)
 		} else {
 			return temp
 		}

--- a/Radix Tree/RadixTree.swift
+++ b/Radix Tree/RadixTree.swift
@@ -181,10 +181,10 @@ public class RadixTree {
         else if shared == e.label {
           currEdge = e
           var tempIndex = searchStr.startIndex
-          for _ in 1...shared.characters.count {
-            tempIndex = searchStr.characters.index(after: tempIndex)
+          for _ in 1...shared.count {
+            tempIndex = searchStr.index(after: tempIndex)
           }
-          searchStr = searchStr.substring(from: tempIndex)
+          searchStr = String(searchStr[tempIndex...])
           found = true
           break
         }
@@ -192,18 +192,18 @@ public class RadixTree {
           // If the child's label and the search string share a partial prefix,
           // then both the label and the search string need to be substringed
           // and a new branch needs to be created
-        else if shared.characters.count > 0 {
-          var labelIndex = e.label.characters.startIndex
+        else if shared.count > 0 {
+          var labelIndex = e.label.startIndex
 
           // Create index objects and move them to after the shared prefix
-          for _ in 1...shared.characters.count {
-            index = searchStr.characters.index(after: index)
-            labelIndex = e.label.characters.index(after: labelIndex)
+          for _ in 1...shared.count {
+            index = searchStr.index(after: index)
+            labelIndex = e.label.index(after: labelIndex)
           }
 
           // Substring both the search string and the label from the shared prefix
-          searchStr = searchStr.substring(from: index)
-          e.label = e.label.substring(from: labelIndex)
+          searchStr = String(searchStr[index...])
+          e.label = String(e.label[labelIndex...])
 
           // Create 2 new edges and update parent/children values
           let newEdge = Edge(e.label)
@@ -266,16 +266,16 @@ public class RadixTree {
         if shared == c.label {
           currEdge = c
           var tempIndex = searchStr.startIndex
-          for _ in 1...shared.characters.count {
-            tempIndex = searchStr.characters.index(after: tempIndex)
+          for _ in 1...shared.count {
+            tempIndex = searchStr.index(after: tempIndex)
           }
-          searchStr = searchStr.substring(from: tempIndex)
+          searchStr = String(searchStr[tempIndex...])
           found = true
           break
         }
 
           // If the shared string is empty, go to the next child
-        else if shared.characters.count == 0 {
+        else if shared.count == 0 {
           continue
         }
 
@@ -287,7 +287,7 @@ public class RadixTree {
           // If the search string and the child's label only share some characters,
           // the string is not in the tree, return false
         else if shared[shared.startIndex] == c.label[c.label.startIndex] &&
-          shared.characters.count < c.label.characters.count {
+          shared.count < c.label.count {
           return false
         }
       }
@@ -340,10 +340,10 @@ public class RadixTree {
         if shared == currEdge.children[c].label {
           currEdge = currEdge.children[c]
           var tempIndex = searchStr.startIndex
-          for _ in 1...shared.characters.count {
-            tempIndex = searchStr.characters.index(after: tempIndex)
+          for _ in 1...shared.count {
+            tempIndex = searchStr.index(after: tempIndex)
           }
-          searchStr = searchStr.substring(from: tempIndex)
+          searchStr = String(searchStr[tempIndex...])
           found = true
           break
         }
@@ -366,13 +366,13 @@ public class RadixTree {
 // i.e. sharedPrefix("court", "coral") -> "co"
 public func sharedPrefix(_ str1: String, _ str2: String) -> String {
   var temp = ""
-  var c1 = str1.characters.startIndex
-  var c2 = str2.characters.startIndex
-  for _ in 0...min(str1.characters.count-1, str2.characters.count-1) {
+  var c1 = str1.startIndex
+  var c2 = str2.startIndex
+  for _ in 0...min(str1.count-1, str2.count-1) {
     if str1[c1] == str2[c2] {
       temp.append( str1[c1] )
-      c1 = str1.characters.index(after:c1)
-      c2 = str2.characters.index(after:c2)
+      c1 = str1.index(after:c1)
+      c2 = str2.index(after:c2)
     } else {
       return temp
     }


### PR DESCRIPTION
Radix Tree source files updated to Swift 4 syntax.
Characters removed (deprecated in Swift 4). Substring removed (deprecated in Swift 4). String slicing subscript used for substrings creation.

<!-- Thanks for contributing to the SAC! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist

- [x] I've looked at the [contribution guidelines](https://github.com/raywenderlich/swift-algorithm-club/blob/master/.github/CONTRIBUTING.md).
- [x] This pull request is complete and ready for review.

### Description

<!-- In a short paragraph, describe the PR --> 

