### PR TITLE
[Binary Search Tree] [enum] Fix height

### DIFF
--- a/Binary Search Tree/README.markdown
+++ b/Binary Search Tree/README.markdown
@@ -615,8 +615,8 @@ This implementation is recursive, and each case of the enum will be treated diff
 
   public var height: Int {
     switch self {
-    case .Empty: return 0
-    case .Leaf: return 1
+    case .Empty: return -1
+    case .Leaf: return 0
     case let .Node(left, _, right): return 1 + max(left.height, right.height)
     }
   }

--- a/Binary Search Tree/Solution 2/BinarySearchTree.swift
+++ b/Binary Search Tree/Solution 2/BinarySearchTree.swift
@@ -20,8 +20,8 @@ public enum BinarySearchTree<T: Comparable> {
   /* Distance of this node to its lowest leaf. Performance: O(n). */
   public var height: Int {
     switch self {
-    case .empty: return 0
-    case .leaf: return 1
+    case .empty: return -1
+    case .leaf: return 0
     case let .node(left, _, right): return 1 + max(left.height, right.height)
     }
   }


### PR DESCRIPTION
### Checklist

- [x] I've looked at the [contribution guidelines](https://github.com/raywenderlich/swift-algorithm-club/blob/master/.github/CONTRIBUTING.md).
- [x] This pull request is complete and ready for review.

### Description

In accordance with the [terminology](https://en.wikipedia.org/wiki/Tree_(data_structure)#Terminology), leaf nodes have height **zero**, and a tree with only a single node (hence both a root and leaf) has height **zero**. Conventionally, an empty tree (tree with no nodes, if such are allowed) has height **−1**.
