### PR TITLE
Fixed issue in LinkedList insert(_:, at:) method where next?.previous…

### DIFF
--- a/Linked List/LinkedList.playground/Contents.swift
+++ b/Linked List/LinkedList.playground/Contents.swift
@@ -176,7 +176,7 @@ public final class LinkedList<T> {
             list.head?.previous = prev
             
             list.last?.next = next
-            next?.previous = list.last?.next
+            next?.previous = list.last
         }
     }
     

--- a/Linked List/LinkedList.swift
+++ b/Linked List/LinkedList.swift
@@ -166,7 +166,7 @@ public final class LinkedList<T> {
             list.head?.previous = prev
             
             list.last?.next = next
-            next?.previous = list.last?.next
+            next?.previous = list.last
         }
     }
     


### PR DESCRIPTION
… was referencing next itself.

<!-- Thanks for contributing to the SAC! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist

- [x] I've looked at the [contribution guidelines](https://github.com/raywenderlich/swift-algorithm-club/blob/master/.github/CONTRIBUTING.md).
- [x] This pull request is complete and ready for review.

### Description

Small fix in the insert(_ list: LinkedList, at index: Int) method of the LinkedList class.
In the LinkedList Swift file (line 169) and the Playground page (line 179), the previous property of the next node was being set to the next node itself, instead of the inserted list's last node.
<!-- In a short paragraph, describe the PR --> 

