### PR TITLE
Fix Rabin-Karp warnings

### DIFF
--- a/Rabin-Karp/Rabin-Karp.playground/Contents.swift
+++ b/Rabin-Karp/Rabin-Karp.playground/Contents.swift
@@ -1,6 +1,6 @@
 //: Taking our rabin-karp algorithm for a walk
 
-// last checked with Xcode 9.0b4
+// last checked with Xcode 9.4
 #if swift(>=4.0)
 print("Hello, Swift 4!")
 #endif
@@ -30,8 +30,8 @@ extension Character {
 // Find first position of pattern in the text using Rabin Karp algorithm
 public func search(text: String, pattern: String) -> Int {
     // convert to array of ints
-    let patternArray = pattern.flatMap { $0.asInt }
-    let textArray = text.flatMap { $0.asInt }
+    let patternArray = pattern.compactMap { $0.asInt }
+    let textArray = text.compactMap { $0.asInt }
 
     if textArray.count < patternArray.count {
         return -1

--- a/Rabin-Karp/Rabin-Karp.playground/playground.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Rabin-Karp/Rabin-Karp.playground/playground.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>


### PR DESCRIPTION
### Checklist

- [ x] I've looked at the [contribution guidelines](https://github.com/raywenderlich/swift-algorithm-club/blob/master/.github/CONTRIBUTING.md).
- [ x] This pull request is complete and ready for review.

### Description

since `flatMap(_:)` is deprecated for non-nil result, I changed it for `compactMap(_:)`

