### PR TITLE
Fix time complexity documentation for insertion of `Sequence` into `Heap`

### DIFF
--- a/Heap/Heap.swift
+++ b/Heap/Heap.swift
@@ -100,7 +100,7 @@ public struct Heap<T> {
   
   /**
    * Adds a sequence of values to the heap. This reorders the heap so that
-   * the max-heap or min-heap property still holds. Performance: O(log n).
+   * the max-heap or min-heap property still holds. Performance: O(n log n).
    */
   public mutating func insert<S: Sequence>(_ sequence: S) where S.Iterator.Element == T {
     for value in sequence {


### PR DESCRIPTION
<!-- Thanks for contributing to the SAC! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist

- [x] I've looked at the [contribution guidelines](https://github.com/raywenderlich/swift-algorithm-club/blob/master/.github/CONTRIBUTING.md).
- [x] This pull request is complete and ready for review.

### Description

<!-- In a short paragraph, describe the PR --> 
The documentation of 
```swift
insert<S: Sequence>(_ sequence: S) where S.Iterator.Element == T
```
states that the time complexity of this method is O(log n). This is not correct as it calls this method
```swift 
insert(_ value: T) // time complexity of O(log n)
```
`n` times. 

The overall complexity is thus `O(n log n)`