### PR TITLE
Fixes typo in Linked List README - class to enum

### DIFF
--- a/Linked List/README.markdown
+++ b/Linked List/README.markdown
@@ -555,7 +555,7 @@ enum ListNode<T> {
 }
 ```
 
-The big difference with the class-based version is that any modification you make to this list will result in a *new copy* being created. Whether that's what you want or not depends on the application.
+The big difference with the enum-based version is that any modification you make to this list will result in a *new copy* being created because of [Swift's value semantics](https://developer.apple.com/swift/blog/?id=10). Whether that's what you want or not depends on the application.
 
 [I might fill out this section in more detail if there's a demand for it.]
 


### PR DESCRIPTION
<!-- Thanks for contributing to the SAC! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist

- [x] I've looked at the [contribution guidelines](https://github.com/raywenderlich/swift-algorithm-club/blob/master/.github/CONTRIBUTING.md).
- [x] This pull request is complete and ready for review.

### Description

<!-- In a short paragraph, describe the PR --> 

Near the bottom of the Linked List README there is a short section on alternate approaches. The alternate approach described is to use an `enum` instead of a `class`. In the paragraph following though there was a typo where it referred to the "class-based" version instead of this new "enum-based" version.

Along with fixing that typo I've also expanded that paragraph to include the reasoning for why a copy is made and included a link to Apple's blog post around value and reference types. 