### PR TITLE
Updated Haversine Distance for Swift 4.2

### DIFF
--- a/HaversineDistance/HaversineDistance.playground/Contents.swift
+++ b/HaversineDistance/HaversineDistance.playground/Contents.swift
@@ -1,34 +1,33 @@
-import UIKit
-// last checked with Xcode 9.04
-#if swift(>=4)
-print("Hello, Swift 4!")
-#endif
+import Foundation
 
-func haversineDinstance(la1: Double, lo1: Double, la2: Double, lo2: Double, radius: Double = 6367444.7) -> Double {
+// Position on a sphere in degrees latitude and longitude.
+typealias Coordinate = (lat: Double, lon: Double)
+
+func haversineDistance(a: Coordinate, b: Coordinate, radius: Double = 6367444.7) -> Double {
     
     let haversin = { (angle: Double) -> Double in
-        return (1 - cos(angle))/2
+        return (1.0 - cos(angle)) / 2.0
     }
     
     let ahaversin = { (angle: Double) -> Double in
-        return 2*asin(sqrt(angle))
+        return 2.0 * asin(sqrt(angle))
     }
     
     // Converts from degrees to radians
     let dToR = { (angle: Double) -> Double in
-        return (angle / 360) * 2 * M_PI
+        return angle * Double.pi / 180.0
     }
     
-    let lat1 = dToR(la1)
-    let lon1 = dToR(lo1)
-    let lat2 = dToR(la2)
-    let lon2 = dToR(lo2)
+    let lat1 = dToR(a.lat)
+    let lon1 = dToR(a.lon)
+    let lat2 = dToR(b.lat)
+    let lon2 = dToR(b.lon)
     
     return radius * ahaversin(haversin(lat2 - lat1) + cos(lat1) * cos(lat2) * haversin(lon2 - lon1))
 }
 
-let amsterdam = (52.3702, 4.8952)
-let newYork = (40.7128, -74.0059)
+let amsterdam = (lat: 52.3702, lon: 4.8952)
+let newYork = (lat: 40.7128, lon: -74.0059)
 
-// Google says it's 5857 km so our result is only off by 2km which could be due to all kinds of things, not sure how google calculates the distance or which latitude and longitude google uses to calculate the distance.
-haversineDinstance(la1: amsterdam.0, lo1: amsterdam.1, la2: newYork.0, lo2: newYork.1)
+// The actual distance is ~5857 km. Our result is off by 2km because the Earth is not a perfect sphere.
+haversineDistance(a: amsterdam, b: newYork)

--- a/HaversineDistance/README.md
+++ b/HaversineDistance/README.md
@@ -6,12 +6,10 @@ The haversine formula can be found on [Wikipedia](https://en.wikipedia.org/wiki/
 
 The Haversine Distance is implemented as a function as a class would be kind of overkill.
 
-`haversineDinstance(la1: Double, lo1: Double, la2: Double, lo2: Double, radius: Double = 6367444.7) -> Double`
+`haversineDistance(a: (lat: Double, lon: Double), b: (lat: Double, lon: Double), radius: Double = 6367444.7) -> Double`
 
-- `la1` is the latitude of point 1 in degrees.
-- `lo1` is the longitude of point 1 in degrees.
-- `la2` is the latitude of point 2 in degrees.
-- `lo2` is the longitude of point 2 in degrees.
+- `a` is the latitude and longitude of point 1 in degrees.
+- `b` is the latitude and longitude of point 2 in degrees.
 - `radius` is the radius of the sphere considered in meters, which defaults to the mean radius of the earth (from [WolframAlpha](http://www.wolframalpha.com/input/?i=earth+radius)).
 
 The function contains 3 closures in order to make the code more readable and comparable to the Haversine formula given by the Wikipedia page mentioned above.
@@ -22,4 +20,4 @@ The function contains 3 closures in order to make the code more readable and com
 
 The result of `haversineDistance` is returned in meters.
 
-*Written for Swift Algorithm Club by Jaap Wijnen.*
+*Written for Swift Algorithm Club by Jaap Wijnen. Updated by Randy the Dev.*


### PR DESCRIPTION
<!-- Thanks for contributing to the SAC! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist

- [x] I've looked at the [contribution guidelines](https://github.com/raywenderlich/swift-algorithm-club/blob/master/.github/CONTRIBUTING.md).
- [x] This pull request is complete and ready for review.

### Description

- Updated Haversine Distance playground for Swift 4.2
- Modified function to take tuples for readibility.
- Removed `UIKit` import and replaced it with `Foundation`.
- Simplified degrees to radians closure algorithm.
- Replaced use of deprecated constant `M_PI` with `Double.pi`.
- Added actual reason why the end result is slightly off the real
  distance.
- Updated README.md.
- Fixed typo in method name.

Part of issue #748 
