### PR TITLE
[Swift 4.2] Confirmed Linear Regression to work with Swift 4.2

### DIFF
--- a/Linear Regression/LinearRegression.playground/Contents.swift
+++ b/Linear Regression/LinearRegression.playground/Contents.swift
@@ -2,11 +2,6 @@
 
 import Foundation
 
-// last checked with Xcode 4.0b4
-#if swift(>=4.0)
-print("Hello, Swift 4!")
-#endif
-
 let carAge: [Double] = [10, 8, 3, 3, 2, 1]
 let carPrice: [Double] = [500, 400, 7000, 8500, 11000, 10500]
 var intercept = 0.0
@@ -22,7 +17,7 @@ let numberOfCarAdvertsWeSaw = carPrice.count
 let numberOfIterations = 100
 let alpha = 0.0001
 
-for n in 1...numberOfIterations {
+for _ in 1...numberOfIterations {
     for i in 0..<numberOfCarAdvertsWeSaw {
         let difference = carPrice[i] - predictedCarPrice(carAge[i])
         intercept += alpha * difference

--- a/Linear Regression/README.markdown
+++ b/Linear Regression/README.markdown
@@ -62,7 +62,7 @@ let numberOfCarAdvertsWeSaw = carPrice.count
 let numberOfIterations = 100
 let alpha = 0.0001
 
-for n in 1...numberOfIterations {
+for _ in 1...numberOfIterations {
     for i in 0..<numberOfCarAdvertsWeSaw {
         let difference = carPrice[i] - predictedCarPrice(carAge[i])
         intercept += alpha * difference


### PR DESCRIPTION
<!-- Thanks for contributing to the SAC! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist

- [x] I've looked at the [contribution guidelines](https://github.com/raywenderlich/swift-algorithm-club/blob/master/.github/CONTRIBUTING.md).
- [x] This pull request is complete and ready for review.

### Description

I've confirmed that the linear regression playground still works with Swift 4.2. I also removed a warning by renaming an unused loop variable to `_`.
