### PR TITLE
reserveCapacity missing in README for MergeSort

### DIFF
--- a/Merge Sort/README.markdown
+++ b/Merge Sort/README.markdown
@@ -79,6 +79,7 @@ func merge(leftPile: [Int], rightPile: [Int]) -> [Int] {
 
   // 2
   var orderedPile = [Int]()
+  orderedPile.reserveCapacity(leftPile.count + rightPile.count)
 
   // 3
   while leftIndex < leftPile.count && rightIndex < rightPile.count {
@@ -115,7 +116,7 @@ This method may look scary, but it is quite straightforward:
 
 1. You need two indexes to keep track of your progress for the two arrays while merging.
 
-2. This is the merged array. It is empty right now, but you will build it up in subsequent steps by appending elements from the other arrays.
+2. This is the merged array. It is empty right now, but you will build it up in subsequent steps by appending elements from the other arrays. Since you already know number of elements that will end up in this array, you reserve capacity to avoid reallocation overhead later.
 
 3. This while-loop will compare the elements from the left and right sides and append them into the `orderedPile` while making sure that the result stays in order.
 


### PR DESCRIPTION
<!-- Thanks for contributing to the SAC! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist

- [x] I've looked at the [contribution guidelines](https://github.com/raywenderlich/swift-algorithm-club/blob/master/.github/CONTRIBUTING.md).
- [x] This pull request is complete and ready for review.

### Description

<!-- In a short paragraph, describe the PR --> 

reserveCapacity was missing in README for Merge Sort despite being present in the sample code. 

In my tests, reserving capacity unconditionally right after creating array for merging worked best, sorting a shuffled array with 1 million integers in 11.6% less time.  

Even though it doesn't reduce time complexity, I think that a simple line of code that has so much effect on efficiency should not be omitted. And removing reserveCapacity when required capacity is known precisely in advance is certainly not very _Swift_'y.