### PR TITLE
Fixed error in linear regression formula

### DIFF
--- a/Linear Regression/README.markdown
+++ b/Linear Regression/README.markdown
@@ -75,7 +75,7 @@ for _ in 1...numberOfIterations {
 
 The program loops through each data point (each car age and car price). For each data point it adjusts the intercept and the slope to bring them closer to the correct values. The equations used in the code to adjust the intercept and the slope are based on moving in the direction of the maximal reduction of these variables. This is a *gradient descent*.
 
-We want to minimise the square of the distance between the line and the points. We define a function `J` which represents this distance - for simplicity we consider only one point here. This function `J` is proportional to `((slope.carAge + intercept) - carPrice)) ^ 2`.
+We want to minimise the square of the distance between the line and the points. We define a function `J` which represents this distance - for simplicity we consider only one point here. This function `J` is proportional to `((slope * carAge + intercept) - carPrice)) ^ 2`.
 
 In order to move in the direction of maximal reduction, we take the partial derivative of this function with respect to the slope, and similarly for the intercept. We multiply these derivatives by our factor alpha and then use them to adjust the values of slope and intercept on each iteration.
 


### PR DESCRIPTION
### Checklist

- [x] I've looked at the [contribution guidelines](https://github.com/raywenderlich/swift-algorithm-club/blob/master/.github/CONTRIBUTING.md).
- [x] This pull request is complete and ready for review.

### Description

In the description of the linear regression (iterative) there an error in the formula.
This function `J` is proportional to `((slope * carAge + intercept) - carPrice)) ^ 2`.
not `((slope.carAge + intercept) - carPrice)) ^ 2`!