### PR TITLE
Fix abs of hashValue causing overflow

### DIFF
--- a/Hash Table/HashTable.playground/Sources/HashTable.swift
+++ b/Hash Table/HashTable.playground/Sources/HashTable.swift
@@ -131,7 +131,7 @@ public struct HashTable<Key: Hashable, Value> {
      Returns the given key's array index.
      */
     private func index(forKey key: Key) -> Int {
-        return abs(key.hashValue) % buckets.count
+        return abs(key.hashValue % buckets.count)
     }
 }
 

--- a/Hash Table/README.markdown
+++ b/Hash Table/README.markdown
@@ -141,7 +141,7 @@ The hash table does not do anything yet, so let's add the remaining functionalit
 
 ```swift
   private func index(forKey key: Key) -> Int {
-    return abs(key.hashValue) % buckets.count
+    return abs(key.hashValue % buckets.count)
   }
 ```
 


### PR DESCRIPTION
<!-- Thanks for contributing to the SAC! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist

- [x] I've looked at the [contribution guidelines](https://github.com/raywenderlich/swift-algorithm-club/blob/master/.github/CONTRIBUTING.md).
- [x] This pull request is complete and ready for review.

### Description

<!-- In a short paragraph, describe the PR --> 
This fixes the unlikely event that the generated hashValue happens to be equal to Int.min (can that even happen?), in which case the abs value of it would be Int.max + 1 causing overflow.
