### PR TITLE
insertion sort: performance improvements

### DIFF
--- a/Insertion Sort/InsertionSort.playground/Contents.swift
+++ b/Insertion Sort/InsertionSort.playground/Contents.swift
@@ -1,43 +1,40 @@
-//: Playground - noun: a place where people can play
-
 /// Performs the Insertion sort algorithm to a given array
 ///
 /// - Parameters:
 ///   - array: the array of elements to be sorted
-///   - isOrderedBefore: returns true if the elements provided are in the corect order
+///   - isOrderedBefore: function that given to inputs returns whether should be order before or after.  Allows for different sorts (e.g. change in direction).
 /// - Returns: a sorted array containing the same elements
 func insertionSort<T>(_ array: [T], _ isOrderedBefore: (T, T) -> Bool) -> [T] {
     guard array.count > 1 else { return array }
-    
-    var a = array
-    for x in 1..<a.count {
-        var y = x
-        let temp = a[y]
-        while y > 0 && isOrderedBefore(temp, a[y - 1]) {
-            a[y] = a[y - 1]
-            y -= 1
+    var sortedArray = array
+    for index in 1..<sortedArray.count {
+        if isOrderedBefore(sortedArray[index-1], sortedArray[index]) { continue }
+        for currentIndex in (0..<index).reversed() {
+            if isOrderedBefore(sortedArray[currentIndex], sortedArray[index]) {
+                sortedArray.move(from: index, to: currentIndex + 1)
+                break
+            } else if currentIndex == 0 {
+                sortedArray.move(from: index, to: 0)
+            }
         }
-        a[y] = temp
     }
-    return a
+    return sortedArray
 }
 
 /// Performs the Insertion sort algorithm to a given array
 ///
-/// - Parameter array: the array to be sorted, conatining elements that conform to the Comparable protocol
-/// - Returns: a sorted array containing the same elements
+/// - Parameter array: the array to be sorted, containing elements that conform to the Comparable protocol
+/// - Returns: a sorted array containing the same elements ordered from lowest to highest
 func insertionSort<T: Comparable>(_ array: [T]) -> [T] {
-    var a = array
-    for x in 1..<a.count {
-        var y = x
-        let temp = a[y]
-        while y > 0 && temp < a[y - 1] {
-            a[y] = a[y - 1]
-            y -= 1
-        }
-        a[y] = temp
+    return insertionSort(array, <)
+}
+
+fileprivate extension Array {
+    mutating func move(from: Int, to: Int) {
+        let removed = self[from]
+        self.remove(at: from)
+        self.insert(removed, at: to)
     }
-    return a
 }
 
 let list = [ 10, -1, 3, 9, 2, 27, 8, 5, 1, 3, 0, 26 ]

--- a/Insertion Sort/InsertionSort.swift
+++ b/Insertion Sort/InsertionSort.swift
@@ -2,40 +2,37 @@
 ///
 /// - Parameters:
 ///   - array: the array of elements to be sorted
-///   - isOrderedBefore: returns true if the elements provided are in the corect order
+///   - isOrderedBefore: function that given to inputs returns whether should be order before or after.  Allows for different sorts (e.g. change in direction).
 /// - Returns: a sorted array containing the same elements
 func insertionSort<T>(_ array: [T], _ isOrderedBefore: (T, T) -> Bool) -> [T] {
-  guard array.count > 1 else { return array }
-
-  var a = array
-  for x in 1..<a.count {
-    var y = x
-    let temp = a[y]
-    while y > 0 && isOrderedBefore(temp, a[y - 1]) {
-      a[y] = a[y - 1]
-      y -= 1
+    guard array.count > 1 else { return array }
+    var sortedArray = array
+    for index in 1..<sortedArray.count {
+        if isOrderedBefore(sortedArray[index-1], sortedArray[index]) { continue }
+        for currentIndex in (0..<index).reversed() {
+            if isOrderedBefore(sortedArray[currentIndex], sortedArray[index]) {
+                sortedArray.move(from: index, to: currentIndex + 1)
+                break
+            } else if currentIndex == 0 {
+                sortedArray.move(from: index, to: 0)
+            }
+        }
     }
-    a[y] = temp
-  }
-  return a
+    return sortedArray
 }
 
 /// Performs the Insertion sort algorithm to a given array
 ///
 /// - Parameter array: the array to be sorted, containing elements that conform to the Comparable protocol
-/// - Returns: a sorted array containing the same elements
+/// - Returns: a sorted array containing the same elements ordered from lowest to highest
 func insertionSort<T: Comparable>(_ array: [T]) -> [T] {
-    guard array.count > 1 else { return array }
+    return insertionSort(array, <)
+}
 
-    var a = array
-    for x in 1..<a.count {
-        var y = x
-        let temp = a[y]
-        while y > 0 && temp < a[y - 1] {
-            a[y] = a[y - 1]
-            y -= 1
-        }
-        a[y] = temp
+fileprivate extension Array {
+    mutating func move(from: Int, to: Int) {
+        let removed = self[from]
+        self.remove(at: from)
+        self.insert(removed, at: to)
     }
-    return a
 }


### PR DESCRIPTION
### Checklist

- [X] I've looked at the [contribution guidelines](https://github.com/raywenderlich/swift-algorithm-club/blob/master/.github/CONTRIBUTING.md).
- [X] This pull request is complete and ready for review.

### Description
Having gone through insertion sort, I noticed that the original algorithm did not perform very well with large numbers of numbers.  The reason being - it "shuffles" the numbers to the left one place at a time.  Not sure that's a requirement of the algorithm.  Better to do one "move" when the right spot is found.  This is 2X quicker in my tests for 1000+ results.
Here's a good example of what's going on in this variant of the algorithm (you'll see how 3 leaps over 5 and 6 rather than gets placed between 5 and 6 first).
https://en.wikipedia.org/wiki/Insertion_sort#/media/File:Insertion-sort-example-300px.gif.

Also included better naming, removed duplicate code and updated the comments.