### PR TITLE
Fix infinite recursion in DFS

### DIFF
--- a/Topological Sort/TopologicalSort1.swift
+++ b/Topological Sort/TopologicalSort1.swift
@@ -1,6 +1,7 @@
 extension Graph {
   private func depthFirstSearch(_ source: Node, visited: inout [Node : Bool]) -> [Node] {
     var result = [Node]()
+    visited[source] = true
 
     if let adjacencyList = adjacencyList(forNode: source) {
       for nodeInAdjacencyList in adjacencyList {
@@ -10,7 +11,6 @@ extension Graph {
       }
     }
 
-    visited[source] = true
     return [source] + result
   }
 


### PR DESCRIPTION
Fixes infinite recursion in the DFS algorithm for topological sort caused by graphs with cycles. 
For example the following graph would previously have recursed indefinitely `a->b->a`.

<!-- Thanks for contributing to the SAC! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist

- [x ] I've looked at the [contribution guidelines](https://github.com/raywenderlich/swift-algorithm-club/blob/master/.github/CONTRIBUTING.md).
- [ x] This pull request is complete and ready for review.

### Description

Fixes issue where a cyclical DAG would recurse indefinitely.
