### PR TITLE
Fix incorrect time complexity

### DIFF
--- a/Heap/Heap.swift
+++ b/Heap/Heap.swift
@@ -212,7 +212,7 @@ extension Heap where T: Equatable {
     return nodes.index(where: { $0 == node })
   }
   
-  /** Removes the first occurrence of a node from the heap. Performance: O(n log n). */
+  /** Removes the first occurrence of a node from the heap. Performance: O(n). */
   @discardableResult public mutating func remove(node: T) -> T? {
     if let index = index(of: node) {
       return remove(at: index)


### PR DESCRIPTION
Time complexity of remove() is O(n + log n), which simplifies to O(n).

<!-- Thanks for contributing to the SAC! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist

- [x] I've looked at the [contribution guidelines](https://github.com/raywenderlich/swift-algorithm-club/blob/master/.github/CONTRIBUTING.md).
- [x] This pull request is complete and ready for review.

### Description

Fixes incorrect time complexity.

<!-- In a short paragraph, describe the PR --> 

