### PR TITLE
Modified Trie to add prefix support to boolean contains(), plus unit …

### DIFF
--- a/Trie/Trie/Trie/Trie.swift
+++ b/Trie/Trie/Trie/Trie.swift
@@ -117,9 +117,12 @@ extension Trie {
 
   /// Determines whether a word is in the trie.
   ///
-  /// - Parameter word: the word to check for
+  /// - Parameters:
+  ///   - word: the word to check for
+  ///   - matchPrefix: whether the search word should match
+  ///   if it is only a prefix of other nodes in the trie
   /// - Returns: true if the word is present, false otherwise.
-  func contains(word: String) -> Bool {
+  func contains(word: String, matchPrefix: Bool = false) -> Bool {
     guard !word.isEmpty else {
       return false
     }
@@ -130,7 +133,7 @@ extension Trie {
       }
       currentNode = childNode
     }
-    return currentNode.isTerminating
+    return matchPrefix || currentNode.isTerminating
   }
 
   /// Attempts to walk to the last node of a word.  The

--- a/Trie/Trie/TrieTests/TrieTests.swift
+++ b/Trie/Trie/TrieTests/TrieTests.swift
@@ -167,7 +167,8 @@ class TrieTests: XCTestCase {
     let trieCopy = NSKeyedUnarchiver.unarchiveObject(withFile: filePath) as? Trie
     XCTAssertEqual(trieCopy?.count, trie.count)
   }
-
+  
+  /// Tests whether word prefixes are properly found and returned.
   func testFindWordsWithPrefix() {
     let trie = Trie()
     trie.insert(word: "test")
@@ -189,5 +190,29 @@ class TrieTests: XCTestCase {
     trie.insert(word: "Team")
     let wordsUpperCase = trie.findWordsWithPrefix(prefix: "Te")
     XCTAssertEqual(wordsUpperCase.sorted(), ["team", "test"])
+  }
+
+  /// Tests whether word prefixes are properly detected on a boolean contains() check.
+  func testContainsWordMatchPrefix() {
+    let trie = Trie()
+    trie.insert(word: "test")
+    trie.insert(word: "another")
+    trie.insert(word: "exam")
+    let wordsAll = trie.contains(word: "", matchPrefix: true)
+    XCTAssertEqual(wordsAll, true)
+    let words = trie.contains(word: "ex", matchPrefix: true)
+    XCTAssertEqual(words, true)
+    trie.insert(word: "examination")
+    let words2 = trie.contains(word: "exam", matchPrefix: true)
+    XCTAssertEqual(words2, true)
+    let noWords = trie.contains(word: "tee", matchPrefix: true)
+    XCTAssertEqual(noWords, false)
+    let unicodeWord = "😬😎"
+    trie.insert(word: unicodeWord)
+    let wordsUnicode = trie.contains(word: "😬", matchPrefix: true)
+    XCTAssertEqual(wordsUnicode, true)
+    trie.insert(word: "Team")
+    let wordsUpperCase = trie.contains(word: "Te", matchPrefix: true)
+    XCTAssertEqual(wordsUpperCase, true)
   }
 }


### PR DESCRIPTION
…tests.

<!-- Thanks for contributing to the SAC! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist

- [x] I've looked at the [contribution guidelines](https://github.com/raywenderlich/swift-algorithm-club/blob/master/.github/CONTRIBUTING.md).
- [x] This pull request is complete and ready for review.

### Description

<!-- In a short paragraph, describe the PR --> 
There was already a function for a rapid search to see if the trie contains a word, but there was not an equivalent function that returned in the same (O) time to check for prefix matches.  The existing function findWordsWithPrefix() takes significantly longer because it tracks down all terminating nodes in the subtrie, and is a waste if you're just looking to know if the prefix matches.  A classic use case of this type of boolean request is to determine whether to return a document that matches a find-as-you-type prefix search on a pre-constructed trie of its tokenized contents.

I modified the contains() function to support this functionality for a project a couple years ago, and as I was updating that project it occurred to me that I ought to contribute this minor change upstream.  I've built similar classes in other languages, but your swift version was so clear and elegant that I just used it instead of porting another or rewriting it.

Unit tests were simply adapted from the existing findWordsWithPrefix() tests.
