### PR TITLE
updated depricated hashable values to hash into methods

### DIFF
--- a/Graph/Graph/Edge.swift
+++ b/Graph/Graph/Edge.swift
@@ -29,12 +29,10 @@ extension Edge: CustomStringConvertible {
 
 extension Edge: Hashable {
 
-  public var hashValue: Int {
-    var string = "\(from.description)\(to.description)"
-    if weight != nil {
-      string.append("\(weight!)")
-    }
-    return string.hashValue
+  public func hash(into hasher: inout Hasher) {
+    hasher.combine(from.description)
+    hasher.combine(to.description)
+    hasher.combine(weight)
   }
 }
 

--- a/Graph/Graph/Vertex.swift
+++ b/Graph/Graph/Vertex.swift
@@ -24,8 +24,9 @@ extension Vertex: CustomStringConvertible {
 
 extension Vertex: Hashable {
 
-  public var hashValue: Int {
-    return "\(data)\(index)".hashValue
+  public func hash(into hasher: inout Hasher) {
+    hasher.combine(data)
+    hasher.combine(index)
   }
 
 }


### PR DESCRIPTION
<!-- Thanks for contributing to the SAC! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist

- [ x] I've looked at the [contribution guidelines](https://github.com/raywenderlich/swift-algorithm-club/blob/master/.github/CONTRIBUTING.md).
- [x ] This pull request is complete and ready for review.

### Description
This PR resolves the `'Hashable.hashValue' is deprecated as a protocol requirement` by updating both the `Vertex` and `Edge` structures to  `implementing 'hash(into:)' instead`.

There are many other instances of this warning that need to be addressed but I believe those should be updated on a case by case basis to help keep PR's as small and concise as possible 😁 

#### Before change
##### Vetex
<img width="1037" alt="image" src="https://user-images.githubusercontent.com/4051188/77764658-3b8fac00-6ffa-11ea-99eb-91681de30738.png">

##### Edge
<img width="1032" alt="image" src="https://user-images.githubusercontent.com/4051188/77764732-5bbf6b00-6ffa-11ea-84c4-9130867e10d3.png">

<!-- In a short paragraph, describe the PR --> 

