### PR TITLE
fix: updated LCS string extension to access string directly

### DIFF
--- a/Longest Common Subsequence/LongestCommonSubsequence.playground/Contents.swift
+++ b/Longest Common Subsequence/LongestCommonSubsequence.playground/Contents.swift
@@ -1,4 +1,4 @@
-// last checked with Xcode 9.0b4
+// last checked with Xcode 11.4
 #if swift(>=4.0)
 print("Hello, Swift 4!")
 #endif
@@ -7,10 +7,10 @@ extension String {
   public func longestCommonSubsequence(_ other: String) -> String {
 
     func lcsLength(_ other: String) -> [[Int]] {
-      var matrix = [[Int]](repeating: [Int](repeating: 0, count: other.characters.count+1), count: self.characters.count+1)
+      var matrix = [[Int]](repeating: [Int](repeating: 0, count: other.count+1), count: self.count+1)
 
-      for (i, selfChar) in self.characters.enumerated() {
-        for (j, otherChar) in other.characters.enumerated() {
+      for (i, selfChar) in self.enumerated() {
+        for (j, otherChar) in other.enumerated() {
           if otherChar == selfChar {
             matrix[i+1][j+1] = matrix[i][j] + 1
           } else {
@@ -22,8 +22,8 @@ extension String {
     }
 
     func backtrack(_ matrix: [[Int]]) -> String {
-      var i = self.characters.count
-      var j = other.characters.count
+      var i = self.count
+      var j = other.count
       var charInSequence = self.endIndex
 
       var lcs = String()
@@ -41,7 +41,7 @@ extension String {
           lcs.append(self[charInSequence])
         }
       }
-      return String(lcs.characters.reversed())
+      return String(lcs.reversed())
     }
 
     return backtrack(lcsLength(other))


### PR DESCRIPTION
<!-- Thanks for contributing to the SAC! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist

- [x] I've looked at the [contribution guidelines](https://github.com/raywenderlich/swift-algorithm-club/blob/master/.github/CONTRIBUTING.md).
- [x] This pull request is complete and ready for review.

### Description
* updated longest common subsequence string extension to access `String` directly, not through `charchaters`.
* updated header to reflect last version of Xcode checked on

#### Errors before change
<img width="1472" alt="image" src="https://user-images.githubusercontent.com/4051188/78950086-7ece2e00-7a82-11ea-8903-0f510a775008.png">
<!-- In a short paragraph, describe the PR --> 

