### PR TITLE
Updating how String can be casted into an Array.

### DIFF
--- a/Knuth-Morris-Pratt/KnuthMorrisPratt.swift
+++ b/Knuth-Morris-Pratt/KnuthMorrisPratt.swift
@@ -12,8 +12,8 @@ extension String {
   
   func indexesOf(ptnr: String) -> [Int]? {
     
-    let text = Array(self.characters)
-    let pattern = Array(ptnr.characters)
+    let text = Array(self)
+    let pattern = Array(ptnr)
     
     let textLength: Int = text.count
     let patternLength: Int = pattern.count


### PR DESCRIPTION
Just wanted to update the syntax from Array(self.characters) to Array(self). Similarly for casting of the ptnr String.

<!-- Thanks for contributing to the SAC! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist

- [x] I've looked at the [contribution guidelines](https://github.com/raywenderlich/swift-algorithm-club/blob/master/.github/CONTRIBUTING.md).
- [x] This pull request is complete and ready for review.

### Description

<!-- In a short paragraph, describe the PR --> 

