### PR TITLE
Update BTree.swift

### DIFF
--- a/B-Tree/BTree.playground/Sources/BTree.swift
+++ b/B-Tree/BTree.playground/Sources/BTree.swift
@@ -86,7 +86,7 @@ extension BTreeNode {
   }
 }
 
-// MARK: BTreeNode extension: Travelsals
+// MARK: BTreeNode extension: Traversals
 
 extension BTreeNode {
 
@@ -443,7 +443,7 @@ public class BTree<Key: Comparable, Value> {
   }
 }
 
-// MARK: BTree extension: Travelsals
+// MARK: BTree extension: Traversals
 
 extension BTree {
   /**


### PR DESCRIPTION
Fix spelling of swift markers - rename `Travelsals` to `Traversals`

<!-- Thanks for contributing to the SAC! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist

- [x] I've looked at the [contribution guidelines](https://github.com/raywenderlich/swift-algorithm-club/blob/master/.github/CONTRIBUTING.md).
- [x] This pull request is complete and ready for review.

### Description

<!-- In a short paragraph, describe the PR --> 

Thanks for making this excellent learning material. As I was going through the `BTree` code, I noticed that the word "traversal" was typed incorrectly. This PR intends to fix the spelling of that word.