### PR TITLE
Improved LinkedList: init from Sequence

### DIFF
--- a/Linked List/LinkedList.playground/Contents.swift
+++ b/Linked List/LinkedList.playground/Contents.swift
@@ -272,12 +272,12 @@ extension LinkedList {
     }
 }
 
-// MARK: - Extension to enable initialization from an Array
+// MARK: - Extension to enable initialization from a Sequence
 extension LinkedList {
-    convenience init(array: Array<T>) {
+    convenience init<S>(_ sequence: S) where S: Sequence, S.Element == T {
         self.init()
         
-        array.forEach { append($0) }
+        sequence.forEach { append($0) }
     }
 }
 

--- a/Linked List/LinkedList.swift
+++ b/Linked List/LinkedList.swift
@@ -266,12 +266,12 @@ extension LinkedList {
     }
 }
 
-// MARK: - Extension to enable initialization from an Array
+// MARK: - Extension to enable initialization from a Sequence
 extension LinkedList {
-    convenience init(array: Array<T>) {
+    convenience init<S>(_ sequence: S) where S: Sequence, S.Element == T {
         self.init()
         
-        array.forEach { append($0) }
+        sequence.forEach { append($0) }
     }
 }
 

--- a/Linked List/Tests/LinkedListTests.swift
+++ b/Linked List/Tests/LinkedListTests.swift
@@ -307,6 +307,17 @@ class LinkedListTest: XCTestCase {
         XCTAssertEqual(nodeCount, list.count)
     }
     
+    func testSequenceInitTypeInfer() {
+        let arrayInitInfer = LinkedList([1.0, 2.0, 3.0])
+
+        XCTAssertEqual(arrayInitInfer.count, 3)
+        XCTAssertEqual(arrayInitInfer.head?.value, 1.0)
+        XCTAssertEqual(arrayInitInfer.last?.value, 3.0)
+        XCTAssertEqual(arrayInitInfer[1], 2.0)
+        XCTAssertEqual(arrayInitInfer.removeLast(), 3.0)
+        XCTAssertEqual(arrayInitInfer.count, 2)
+    }
+
     func testArrayLiteralInitTypeInfer() {
         let arrayLiteralInitInfer: LinkedList = [1.0, 2.0, 3.0]
         


### PR DESCRIPTION
<!-- Thanks for contributing to the SAC! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist

- [x] I've looked at the [contribution guidelines](https://github.com/raywenderlich/swift-algorithm-club/blob/master/.github/CONTRIBUTING.md).
- [x] This pull request is complete and ready for review.

### Description

The `.init` was taking `Arrays` only not other `Sequence` types. It's a very small change and I added test scenario for it.

