### PR TITLE
index(where:) deprecated

### DIFF
--- a/Heap/Heap.swift
+++ b/Heap/Heap.swift
@@ -209,7 +209,7 @@ extension Heap where T: Equatable {
   
   /** Get the index of a node in the heap. Performance: O(n). */
   public func index(of node: T) -> Int? {
-    return nodes.index(where: { $0 == node })
+    return nodes.firstIndex(where: { $0 == node })
   }
   
   /** Removes the first occurrence of a node from the heap. Performance: O(n). */


### PR DESCRIPTION
Updating searching method for finding a node's index. Updating it's return value to be nodes.firstIndex(where: { $0 == node })

<!-- Thanks for contributing to the SAC! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist

- [ ] I've looked at the [contribution guidelines](https://github.com/raywenderlich/swift-algorithm-club/blob/master/.github/CONTRIBUTING.md).
- [ ] This pull request is complete and ready for review.

### Description

<!-- In a short paragraph, describe the PR --> 

