### PR TITLE
Improve LinkedList Array initliasier

### DIFF
--- a/Linked List/LinkedList.swift
+++ b/Linked List/LinkedList.swift
@@ -270,8 +270,18 @@ extension LinkedList {
 extension LinkedList {
     convenience init(array: Array<T>) {
         self.init()
-        
-        array.forEach { append($0) }
+        guard let first = array.first else {
+            return
+        }
+        var node = Node(value: first)
+        append(node)
+
+        for item in array[1...] {
+            let next = Node(value: item)
+            node.next = next
+            next.previous = node
+            node = next
+        }
     }
 }
 

--- a/Linked List/Tests/LinkedListTests.swift
+++ b/Linked List/Tests/LinkedListTests.swift
@@ -336,4 +336,16 @@ class LinkedListTest: XCTestCase {
         
         XCTAssertTrue(value == 3)
     }
+
+    func testArrayInit() {
+        let testArray = Array(1...10_000)
+
+        let list = LinkedList(array: testArray)
+
+        XCTAssertEqual(list.head?.value, 1)
+        XCTAssertEqual(list.last?.value, 10_000)
+
+        XCTAssertEqual(list.count, 10_000)
+    }
+
 }


### PR DESCRIPTION

### Checklist

- [x] I've looked at the [contribution guidelines](https://github.com/raywenderlich/swift-algorithm-club/blob/master/.github/CONTRIBUTING.md).
- [x] This pull request is complete and ready for review.

### Description

Improves the Linked List initiliaser to not use append for each element. 
When using append, it goes through the whole LinkedList everytime an item is appended.

Init with 10k Items before:
> Executed 1 test, with 0 failures (0 unexpected) in 8.394 (8.395) seconds
Init with 10k Items after:
> Executed 1 test, with 0 failures (0 unexpected) in 0.083 (0.084) seconds

Only issue I found, is that the Test crashes with a Bad Access, when using 100k items. I stopped testing if that happens with the old implementation after 50k though, because it already took a couple of minutes to get to 50k and it gets slower, the more items are added.

I didn't change the arrayLiteral initialiser, because I don't see anyone, typing that many numbers :)
