### PR TITLE
fix(link-list): remove append of node by node in list appending method, we can append the newLinkedList head to the oldLinkedList last(tail) item.

### DIFF
--- a/Linked List/LinkedList.playground/Contents.swift
+++ b/Linked List/LinkedList.playground/Contents.swift
@@ -81,12 +81,9 @@ public final class LinkedList<T> {
             var node = head!.next
             for _ in 1..<index {
                 node = node?.next
-                if node == nil {
-                    break
-                }
+                assert(node != nil , "index is out of bounds.")
             }
             
-            assert(node != nil, "index is out of bounds.")
             return node!
         }
     }
@@ -116,11 +113,12 @@ public final class LinkedList<T> {
     ///
     /// - Parameter list: The list to be copied and appended.
     public func append(_ list: LinkedList) {
-        var nodeToCopy = list.head
-        while let node = nodeToCopy {
-            append(node.value)
-            nodeToCopy = node.next
+        
+        guard let headNode = list.head else {
+            return
         }
+        
+        append(headNode)
     }
     
     /// Insert a value at a specific index. Crashes if index is out of bounds (0...self.count)
@@ -380,13 +378,18 @@ list2.append("World")
 list.append(list2)            // [Hello, World, Goodbye, World]
 list2.removeAll()             // [ ]
 list2.isEmpty                 // true
+
+
+print(list)
 list.removeLast()             // "World"
+list
 list.remove(at: 2)       // "Goodbye"
 
 list.insert("Swift", at: 1)
 list[0]     // "Hello"
 list[1]     // "Swift"
 list[2]     // "World"
+//list[10]     // crash!!
 print(list)
 
 list.reverse()   // [World, Swift, Hello]

--- a/Linked List/LinkedList.playground/Contents.swift
+++ b/Linked List/LinkedList.playground/Contents.swift
@@ -379,10 +379,7 @@ list.append(list2)            // [Hello, World, Goodbye, World]
 list2.removeAll()             // [ ]
 list2.isEmpty                 // true
 
-
-print(list)
 list.removeLast()             // "World"
-list
 list.remove(at: 2)       // "Goodbye"
 
 list.insert("Swift", at: 1)


### PR DESCRIPTION
<!-- Thanks for contributing to the SAC! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist

- [X] I've looked at the [contribution guidelines](https://github.com/raywenderlich/swift-algorithm-club/blob/master/.github/CONTRIBUTING.md).
- [X] This pull request is complete and ready for review.

### Description

<!-- In a short paragraph, describe the PR --> 
The current logic of appending a new linked list into a current link list is being appended sequentially ignoring the fact that we already got two connected link lists, hence we should connect the old link list last item (tail) to the head of the new linked list.
This P.R refactor this 
