### PR TITLE
fixes label-less method parameter

### DIFF
--- a/Linked List/README.markdown
+++ b/Linked List/README.markdown
@@ -139,7 +139,7 @@ But that doesn't feel very Swifty to me. We might as well make use of Swift's bu
 Of course, `last` only returns nil because we don't have any nodes in the list. Let's add a method that adds a new node to the end of the list:
 
 ```swift
-  public func append(value: T) {
+  public func append(_ value: T) {
     let newNode = Node(value: value)
     if let lastNode = last {
       newNode.previous = lastNode


### PR DESCRIPTION
The following code samples all use `append(_:)` without the `value:` label and since Swift 3 (https://github.com/apple/swift-evolution/blob/master/proposals/0046-first-label.md) this has to be implemented with a preceding `_` in the function signature.

### Checklist

- [x] I've looked at the [contribution guidelines](https://github.com/raywenderlich/swift-algorithm-club/blob/master/.github/CONTRIBUTING.md).
- [x] This pull request is complete and ready for review.

### Description

This is an update to one of the source code samples.  
Your README.md states compatibility with Swift4.2, so this change from Swift 3 is warranted, I hope.
Feel free to deny the PR if I should have overlooked something.
