### PR TITLE
extend OrderedSet with convenience methods ensure_at_front/end..

### DIFF
--- a/Ordered Set/OrderedSet.swift
+++ b/Ordered Set/OrderedSet.swift
@@ -73,5 +73,38 @@ public class OrderedSet<T: Hashable> {
   public func all() -> [T] {
     return objects
   }
+
+  // convenience checker - minimize need for client's knowledge of internals
+  public func contains(_ object: T) ->Bool {
+      return indexOfKey[object] != nil
+  }
+  
+  // O(1)
+  // append object (removing any existing other occurence)
+  public func ensure_at_end(_ object: T) {
+      if contains(object) {
+          remove(object)
+      }
+      add(object)
+  }
+  
+  // O(n)
+  // prepend object (removing any existing other occurence)
+  public func ensure_at_front(_ object: T) {
+      if contains(object) {
+          remove(object)      // could make this more efficient (at the expense of maintenance complexity) by not delegating to remove() and insert()
+                              // but instead doing manually, and running for loop just once at end
+      }
+      insert(object, at:0)
+      
+  }
+  
+  func debug_str() -> String  // useful for printing/debugging
+  {
+      var str = "OrderedSet: \n"
+      str += objects.map{"\($0)"}.joined(separator: ",")
+      
+      return str
+  }
 }
 


### PR DESCRIPTION
…l eg in implementing a list of "recent documents"

<!-- Thanks for contributing to the SAC! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist

- [x] I've looked at the [contribution guidelines](https://github.com/raywenderlich/swift-algorithm-club/blob/master/.github/CONTRIBUTING.md).
- [x] This pull request is complete and ready for review.

### Description

<!-- In a short paragraph, describe the PR --> 
For situations such as implementing a list of "recent documents" eg for text editor, it's necessary to maintain an ordered set, but with the additional capability of prepending/appending a new instance if the object doesn't yet exist in the set, **or** if it does, shifting the object to the front/back. This functionality has been added.
Furthermore, the convenience method `contains`, which can be used by clients without requiring them to know the internal representation of the class, (and `debug_str` useful for printing/debugging)
